### PR TITLE
Fix hanging with every copy on Wayland

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -52,8 +52,7 @@ Result<int> start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
         close(copy_pipe[1]);
         dup2(copy_pipe[0], STDIN_FILENO);
         close(copy_pipe[0]);
-        execvp("wl-copy",
-               (char* [5]){ (char*)"wl-copy", (char*)"--foreground", (char*)"--type", (char*)mime_type.c_str(), NULL });
+        execlp("wl-copy", "wl-copy", "--foreground", "--type", mime_type.c_str(), NULL);
 
         exit(-1);
     }

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -74,10 +74,12 @@ Result<int> start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
 
 Result<> Clipboard::CopyText(const std::string& text)
 {
+#ifndef _WIN32
     // Fuck you, fuck your software monopoly
     // and fuck your stupid standards that nobody wants to follow
     if (m_session != SessionType::Wayland)
     {
+#endif
         if (!g_is_systray)
         {
             const Result<>& res = g_sender->Send(text);
@@ -89,8 +91,8 @@ Result<> Clipboard::CopyText(const std::string& text)
         if (clip::set_text(text))
             return Ok();
         return Err("Failed to copy text into clipboard");
+#ifndef _WIN32
     }
-
     Result<int> res = start_wlcopy();
     if (!res.ok())
         return res.error();
@@ -106,6 +108,7 @@ Result<> Clipboard::CopyText(const std::string& text)
     close(fd);
 
     return Ok();
+#endif
 }
 
 Result<> Clipboard::CopyImage(const capture_result_t& cap)

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -1,11 +1,5 @@
 #include "clipboard.hpp"
 
-#ifndef _WIN32
-#  include <sys/wait.h>
-#  include <unistd.h>
-#endif
-
-#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -24,19 +18,23 @@
 // used to track the wl-copy process
 static int wlcopy_pid = -1;
 
+#ifdef __linux__
+#  include <sys/wait.h>
+#  include <unistd.h>
+#endif
+
 // Starts wlcopy in the background, forgetting it.
 // Sets wlcopy_pid, and returns an stdin pipe on success.
-Result<int> Start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-8")
+Result<int> start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-8")
 {
+#ifdef __linux__
     // stop if already launched
     if (wlcopy_pid > 0)
     {
         kill(wlcopy_pid, SIGINT);
 
-#ifndef _WIN32
         // we need to do this on Linux, because the process will be defunct otherwise.
         waitpid(wlcopy_pid, NULL, 0);
-#endif
 
         wlcopy_pid = -1;
     }
@@ -54,7 +52,8 @@ Result<int> Start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
         close(copy_pipe[1]);
         dup2(copy_pipe[0], STDIN_FILENO);
         close(copy_pipe[0]);
-        execlp("wl-copy", "wl-copy", "--foreground", "--type", mime_type.c_str(), NULL);
+        execvp("wl-copy",
+               (char* [5]){ (char*)"wl-copy", (char*)"--foreground", (char*)"--type", (char*)mime_type.c_str(), NULL });
 
         exit(-1);
     }
@@ -68,6 +67,9 @@ Result<int> Start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
     }
 
     return Ok(copy_pipe[1]);
+#else
+    return Err("wl-copy scheme is not supported on non-linux systems!");
+#endif
 }
 
 Result<> Clipboard::CopyText(const std::string& text)
@@ -89,11 +91,9 @@ Result<> Clipboard::CopyText(const std::string& text)
         return Err("Failed to copy text into clipboard");
     }
 
-    Result<int> res = Start_wlcopy();
+    Result<int> res = start_wlcopy();
     if (!res.ok())
-    {
         return res.error();
-    }
 
     int fd = res.get();
 
@@ -120,7 +120,7 @@ Result<> Clipboard::CopyImage(const capture_result_t& cap)
 
         svpng(&png, cap.w, cap.h, cap.view().data(), 1);
 
-        Result<int> res = Start_wlcopy("image/png");
+        Result<int> res = start_wlcopy("image/png");
 
         if (!res.ok())
         {

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -1,7 +1,9 @@
 #include "clipboard.hpp"
 
-#include <sys/wait.h>
-#include <unistd.h>
+#ifndef _WIN32
+#  include <sys/wait.h>
+#  include <unistd.h>
+#endif
 
 #include <csignal>
 #include <cstdint>
@@ -31,8 +33,10 @@ Result<int> Start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
     {
         kill(wlcopy_pid, SIGINT);
 
-        // we need to do this, because the process will be defunct otherwise.
+#ifndef _WIN32
+        // we need to do this on Linux, because the process will be defunct otherwise.
         waitpid(wlcopy_pid, NULL, 0);
+#endif
 
         wlcopy_pid = -1;
     }

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -74,7 +74,7 @@ Result<int> start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
 
 Result<> Clipboard::CopyText(const std::string& text)
 {
-#ifndef _WIN32
+#ifdef __linux__
     // Fuck you, fuck your software monopoly
     // and fuck your stupid standards that nobody wants to follow
     if (m_session != SessionType::Wayland)
@@ -91,7 +91,7 @@ Result<> Clipboard::CopyText(const std::string& text)
         if (clip::set_text(text))
             return Ok();
         return Err("Failed to copy text into clipboard");
-#ifndef _WIN32
+#ifdef __linux__
     }
     Result<int> res = start_wlcopy();
     if (!res.ok())
@@ -117,6 +117,8 @@ Result<> Clipboard::CopyImage(const capture_result_t& cap)
         return Err("Image size is 0");
 
     std::string err;
+
+#ifdef __linux__
     if (m_session == SessionType::Wayland)
     {
         std::vector<uint8_t> png;
@@ -143,6 +145,7 @@ Result<> Clipboard::CopyImage(const capture_result_t& cap)
 
         return Ok();
     }
+#endif
 
     if (!g_is_systray)
     {

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -24,7 +24,7 @@ static int wlcopy_pid = -1;
 
 // Starts wlcopy in the background, forgetting it.
 // Sets wlcopy_pid, and returns an stdin pipe on success.
-Result<int> Start_wlcopy(const std::string& mime_type = "text/plain")
+Result<int> Start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-8")
 {
     // stop if already launched
     if (wlcopy_pid > 0)

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -6,6 +6,7 @@
 
 #include "clip/clip.h"
 #include "socket.hpp"
+#include "tiny-process-library/process.hpp"
 
 #define SVPNG_LINKAGE inline
 #define SVPNG_OUTPUT  std::vector<uint8_t>* output
@@ -98,6 +99,7 @@ Result<> Clipboard::CopyText(const std::string& text)
 
     if (write(fd, text.c_str(), text.size()) == -1)
     {
+        close(fd);
         return Err("Failed to copy text: " + std::string(strerror(errno)));
     }
 
@@ -129,7 +131,10 @@ Result<> Clipboard::CopyImage(const capture_result_t& cap)
         int fd = res.get();
 
         if (write(fd, reinterpret_cast<const char*>(png.data()), png.size()) == -1)
+        {
+            close(fd);
             return Err("Failed to write image to stdin: " + std::string(strerror(errno)));
+        }
 
         close(fd);
 

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -1,10 +1,14 @@
 #include "clipboard.hpp"
 
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
 #include <cstdint>
+#include <cstring>
 
 #include "clip/clip.h"
 #include "socket.hpp"
-#include "tiny-process-library/process.hpp"
 
 #define SVPNG_LINKAGE inline
 #define SVPNG_OUTPUT  std::vector<uint8_t>* output
@@ -13,6 +17,51 @@
 #pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #include "svpng.h"
 #pragma GCC diagnostic pop
+
+// used to track the wl-copy process
+static int wlcopy_pid = -1;
+
+// Starts wlcopy in the background, forgetting it.
+// Sets wlcopy_pid, and returns an stdin pipe on success.
+Result<int> Start_wlcopy(const std::string& mime_type = "text/plain")
+{
+    // stop if already launched
+    if (wlcopy_pid > 0)
+    {
+        kill(wlcopy_pid, SIGINT);
+
+        // we need to do this, because the process will be defunct otherwise.
+        waitpid(wlcopy_pid, NULL, 0);
+
+        wlcopy_pid = -1;
+    }
+
+    int copy_pipe[2];
+    if (pipe(copy_pipe) == -1)
+    {
+        return Err("Failed to open stdin pipe: " + std::string(strerror(errno)));
+    }
+
+    wlcopy_pid = fork();
+
+    if (wlcopy_pid == 0)
+    {
+        close(copy_pipe[1]);
+        dup2(copy_pipe[0], STDIN_FILENO);
+        close(copy_pipe[0]);
+        execlp("wl-copy", "wl-copy", "--foreground", "--type", mime_type.c_str(), NULL);
+
+        return Err("execlp failed: " + std::string(strerror(errno)));
+    }
+    else if (wlcopy_pid < 0)
+    {
+        return Err("Failed to fork: " + std::string(strerror(errno)));
+    }
+
+    close(copy_pipe[0]);
+
+    return Ok(copy_pipe[1]);
+}
 
 Result<> Clipboard::CopyText(const std::string& text)
 {
@@ -33,15 +82,22 @@ Result<> Clipboard::CopyText(const std::string& text)
         return Err("Failed to copy text into clipboard");
     }
 
-    std::string err;
+    Result<int> res = Start_wlcopy();
+    if (!res.ok())
+    {
+        return res.error();
+    }
 
-    // Use foreground mode so the process doesn't fork away from our pipes.
-    TinyProcessLib::Process proc(
-        { "wl-copy", "--foreground", text }, "", nullptr, [&](const char* b, size_t n) { err.append(b, n); });
+    int fd = res.get();
 
-    if (proc.get_exit_status() == 0)
-        return Ok();
-    return Err("Failed to copy text into clipboard: " + err);
+    if (write(fd, text.c_str(), text.size()) == -1)
+    {
+        return Err("Failed to copy text: " + std::string(strerror(errno)));
+    }
+
+    close(fd);
+
+    return Ok();
 }
 
 Result<> Clipboard::CopyImage(const capture_result_t& cap)
@@ -57,19 +113,21 @@ Result<> Clipboard::CopyImage(const capture_result_t& cap)
 
         svpng(&png, cap.w, cap.h, cap.view().data(), 1);
 
-        // Use foreground mode so the process doesn't fork away from our pipes.
-        TinyProcessLib::Process proc(
-            { "wl-copy", "--foreground", "--type", "image/png" }, "", nullptr, [&](const char* b, size_t n) {
-                err.append(b, n);
-            });
+        Result<int> res = Start_wlcopy("image/png");
 
-        if (!proc.write(reinterpret_cast<const char*>(png.data()), png.size()))
-            return Err("Failed to write image to stdin");
+        if (!res.ok())
+        {
+            return res.error();
+        }
 
-        proc.close_stdin();
-        if (proc.get_exit_status() == 0)
-            return Ok();
-        return Err("Failed to copy image into clipboard");
+        int fd = res.get();
+
+        if (write(fd, reinterpret_cast<const char*>(png.data()), png.size()) == -1)
+            return Err("Failed to write image to stdin: " + std::string(strerror(errno)));
+
+        close(fd);
+
+        return Ok();
     }
 
     if (!g_is_systray)

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -54,12 +54,14 @@ Result<int> Start_wlcopy(const std::string& mime_type = "text/plain;charset=utf-
 
         exit(-1);
     }
-    else if (wlcopy_pid < 0)
-    {
-        return Err("Failed to fork: " + std::string(strerror(errno)));
-    }
 
     close(copy_pipe[0]);
+
+    if (wlcopy_pid < 0)
+    {
+        close(copy_pipe[1]);
+        return Err("Failed to fork: " + std::string(strerror(errno)));
+    }
 
     return Ok(copy_pipe[1]);
 }

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -5,6 +5,7 @@
 
 #include <csignal>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 
 #include "clip/clip.h"
@@ -51,7 +52,7 @@ Result<int> Start_wlcopy(const std::string& mime_type = "text/plain")
         close(copy_pipe[0]);
         execlp("wl-copy", "wl-copy", "--foreground", "--type", mime_type.c_str(), NULL);
 
-        return Err("execlp failed: " + std::string(strerror(errno)));
+        exit(-1);
     }
     else if (wlcopy_pid < 0)
     {


### PR DESCRIPTION
This patch directly uses `fork` and `execlp` to run `wl-copy` in the background, without waiting on it to finish.

The text/image persists, even after oshot exits.