### PR TITLE
Add Nix flakes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,3 +468,9 @@ install(
     DESTINATION share/licenses/${PROJECT_NAME}
     COMPONENT documentation
 )
+
+install(
+    FILES oshot.desktop
+    DESTINATION share/applications
+    COMPONENT documentation
+)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ If when starting oshot, it starts to flick a screen black (or it won't launch), 
 
 If still errors, please open an [Issue](https://github.com/Toni500github/oshot/issues) and take a screenshot/paste the text of the error appearing in the console when executing oshot
 
+### NixOS
+On NixOS, TESSDATA_PREFIX will need to be set for oshot to find the languages.
+You have two ways to do this, depending on how you installed tesseract.
+
+If you installed tesseract in `environment.systemPackages`, set the following variable:
+```nix
+environment.sessionVariables = {
+    # Change tesseract to tesseract5 if that's the package you used.
+    "TESSDATA_PREFIX" = "${pkgs.tesseract}/share/tessdata";
+};
+```
+
+If you installed tesseract in `users.users.<user>.packages`, you could use the above method, but it's better you use home-manager.
+If you have home-manager, add this in your home.nix:
+```nix
+systemd.user.sessionVariables = {
+    # Change tesseract to tesseract5 if that's the package you used.
+    "TESSDATA_PREFIX" = "${pkgs.tesseract}/share/tessdata";
+};
+```
+
+> **__Notice:__** If you're not using systemd, the home-manager solution won't work. We assume you'll be able to find a replacement yourself if you're not using systemd.
+
+If this doesn't work, while `echo $TESSDATA_PREFIX` returns a valid result, check your config file.
+
 ## Usage
 https://github.com/user-attachments/assets/8367490a-f7b0-4320-86e9-8ef8764a56b5
 <!--https://github.com/user-attachments/assets/ac505de6-0818-4d67-bb51-064d86f1f970-->

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         name = "oshot";
         src = self;
         nativeBuildInputs = [ cmake gnumake pkg-config git ];
-        buildInputs = [ glfw3 zenity leptonica libx11.dev tesseract zbar.dev libappindicator-gtk3.dev dbus.dev systemd.dev libsysprof-capture pcre2.dev libxdmcp.dev libuuid.dev libselinux.dev libsepol.dev libthai.dev libdatrie.dev libdeflate lerc.dev xz.dev zstd.dev libwebp libxkbcommon.dev libepoxy.dev libxtst giflib ];
+        buildInputs = [ glfw3 leptonica libx11.dev tesseract zbar.dev libappindicator-gtk3.dev dbus.dev systemd.dev libsysprof-capture pcre2.dev libxdmcp.dev libuuid.dev libselinux.dev libsepol.dev libthai.dev libdatrie.dev libdeflate lerc.dev xz.dev zstd.dev libwebp libxkbcommon.dev libepoxy.dev libxtst giflib ];
         configurePhase = ''
           cmake -DCMAKE_BUILD_PREFIX=/usr -DDEBUG=0 -G "Unix Makefiles" -B build -S .
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Nix flake for oshot; a simple and lightweight tool for extracting text from a screenshot/image (on the fly)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.oshot =
+      with import nixpkgs { system = "x86_64-linux"; };
+      stdenv.mkDerivation {
+        name = "oshot";
+        src = self;
+        nativeBuildInputs = [ cmake gnumake pkg-config git ];
+        buildInputs = [ glfw3 zenity leptonica libx11.dev tesseract zbar.dev libappindicator-gtk3.dev dbus.dev systemd.dev libsysprof-capture pcre2.dev libxdmcp.dev libuuid.dev libselinux.dev libsepol.dev libthai.dev libdatrie.dev libdeflate lerc.dev xz.dev zstd.dev libwebp libxkbcommon.dev libepoxy.dev libxtst giflib ];
+        configurePhase = ''
+          cmake -DCMAKE_BUILD_PREFIX=/usr -DDEBUG=0 -G "Unix Makefiles" -B build -S .
+        '';
+        buildPhase = ''
+          cmake --build build -j$(nproc)
+        '';
+        installPhase = ''
+          install -Dm755 build/oshot $out/bin/oshot
+          install -Dm644 oshot.desktop $out/share/applications/oshot.desktop
+          install -Dm644 LICENSE $out/share/licenses/oshot/LICENSE
+        '';
+      };
+    packages.x86_64-linux.default = self.packages.x86_64-linux.oshot;
+  };
+}

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -292,7 +292,7 @@ void apply_imgui_theme();
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
 # Path to where we'll use all the '.traineddata' models.
 # The TESSDATA_PREFIX environment variable supersedes this.
-ocr-path = "/usr/share/tessdata"
+ocr-path = {}
 
 # Default OCR model.
 ocr-model = "{}"

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -291,7 +291,6 @@ void apply_imgui_theme();
 // default config
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
 # Path to where we'll use all the '.traineddata' models.
-# Takes from the TESSDATA_PREFIX environment variable by default, or `/usr/share/tessdata` on the lack thereof.
 # ocr-path = "/usr/share/tessdata"
 
 # Default OCR model.

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,7 +1,6 @@
 #ifndef _CONFIG_HPP_
 #define _CONFIG_HPP_
 
-#include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <type_traits>
@@ -47,7 +46,7 @@ public:
         // just for out-of-box experience sake, let's use the relative
         // ./models directory for the OCR models.
 #ifdef __linux__
-        std::string ocr_path = "/usr/share/tessdata";
+        std::string ocr_path = "/usr/share/tessdata/";
 #else
         std::string ocr_path = "./models";
 #endif
@@ -290,9 +289,9 @@ void apply_imgui_theme();
 
 // default config
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
-# Path to where we'll use all the '.traineddata' models.
+# Default Path to where we'll use all the '.traineddata' models.
 # The TESSDATA_PREFIX environment variable supersedes this.
-ocr-path = {}
+ocr-path = "{}"
 
 # Default OCR model.
 ocr-model = "{}"

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -291,7 +291,8 @@ void apply_imgui_theme();
 // default config
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
 # Path to where we'll use all the '.traineddata' models.
-# ocr-path = "~/.config/oshot/models"
+# The TESSDATA_PREFIX environment variable supersedes this.
+ocr-path = "~/.config/oshot/models"
 
 # Default OCR model.
 ocr-model = "{}"

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -291,7 +291,7 @@ void apply_imgui_theme();
 // default config
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
 # Path to where we'll use all the '.traineddata' models.
-# ocr-path = "/usr/share/tessdata"
+# ocr-path = "~/.config/oshot/models"
 
 # Default OCR model.
 ocr-model = "{}"

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,6 +1,7 @@
 #ifndef _CONFIG_HPP_
 #define _CONFIG_HPP_
 
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <type_traits>
@@ -46,7 +47,7 @@ public:
         // just for out-of-box experience sake, let's use the relative
         // ./models directory for the OCR models.
 #ifdef __linux__
-        std::string ocr_path = "/usr/share/tessdata/";
+        std::string ocr_path = getenv("TESSDATA_PREFIX");
 #else
         std::string ocr_path = "./models";
 #endif
@@ -289,8 +290,9 @@ void apply_imgui_theme();
 
 // default config
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
-# Default Path to where we'll use all the '.traineddata' models.
-ocr-path = "{}"
+# Path to where we'll use all the '.traineddata' models.
+# Takes from the TESSDATA_PREFIX environment variable by default, or `/usr/share/tessdata` on the lack thereof.
+# ocr-path = "/usr/share/tessdata"
 
 # Default OCR model.
 ocr-model = "{}"

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -292,7 +292,7 @@ void apply_imgui_theme();
 inline constexpr std::string_view AUTOCONFIG = R"#([default]
 # Path to where we'll use all the '.traineddata' models.
 # The TESSDATA_PREFIX environment variable supersedes this.
-ocr-path = "~/.config/oshot/models"
+ocr-path = "/usr/share/tessdata"
 
 # Default OCR model.
 ocr-model = "{}"

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -47,7 +47,7 @@ public:
         // just for out-of-box experience sake, let's use the relative
         // ./models directory for the OCR models.
 #ifdef __linux__
-        std::string ocr_path = getenv("TESSDATA_PREFIX");
+        std::string ocr_path = "/usr/share/tessdata";
 #else
         std::string ocr_path = "./models";
 #endif

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,8 +62,9 @@ void Config::LoadConfigFile(const std::string& filename)
     File.allow_out_edit = GetValue<bool>("default.allow-edit-ocr", false);  // deprecated
     File.allow_out_edit = GetValue<bool>("default.allow-text-edit", File.allow_out_edit);
 
-    const char *tessdata_prefix;
-    if ((tessdata_prefix = getenv("TESSDATA_PREFIX"))) {
+    const char* tessdata_prefix;
+    if ((tessdata_prefix = getenv("TESSDATA_PREFIX")))
+    {
         File.ocr_path = tessdata_prefix;
     }
 }
@@ -161,6 +162,7 @@ void Config::GenerateConfig(const std::string& filename, const bool force)
     }
 
     f.print(AUTOCONFIG,
+            File.ocr_path,
             File.ocr_model,
             File.ocr_get_repo,
             File.delay,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,12 +62,10 @@ void Config::LoadConfigFile(const std::string& filename)
     File.allow_out_edit = GetValue<bool>("default.allow-edit-ocr", false);  // deprecated
     File.allow_out_edit = GetValue<bool>("default.allow-text-edit", File.allow_out_edit);
 
-#ifdef __linux__
     const char *tessdata_prefix;
     if ((tessdata_prefix = getenv("TESSDATA_PREFIX"))) {
         File.ocr_path = tessdata_prefix;
     }
-#endif
 }
 
 void Config::LoadThemeFile(const std::string& filename)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,6 +20,12 @@ Config::Config(const fs::path& configFile, const fs::path& configDir)
         fs::create_directories(configDir / "models");
     }
 
+#ifdef __linux__
+    // on Linux, if ocr_path isn't defined, set it to /usr/share/tessdata.
+    if (File.ocr_path.empty())
+        File.ocr_path = "/usr/share/tessdata";
+#endif
+
     if (!fs::exists(configFile))
     {
         warn("Config file {} not found, generating new one", configFile.string());
@@ -156,7 +162,6 @@ void Config::GenerateConfig(const std::string& filename, const bool force)
     }
 
     f.print(AUTOCONFIG,
-            File.ocr_path,
             File.ocr_model,
             File.ocr_get_repo,
             File.delay,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,12 +20,6 @@ Config::Config(const fs::path& configFile, const fs::path& configDir)
         fs::create_directories(configDir / "models");
     }
 
-#ifdef __linux__
-    // on Linux, if ocr_path isn't defined, set it to /usr/share/tessdata.
-    if (File.ocr_path.empty())
-        File.ocr_path = "/usr/share/tessdata";
-#endif
-
     if (!fs::exists(configFile))
     {
         warn("Config file {} not found, generating new one", configFile.string());
@@ -67,6 +61,13 @@ void Config::LoadConfigFile(const std::string& filename)
 
     File.allow_out_edit = GetValue<bool>("default.allow-edit-ocr", false);  // deprecated
     File.allow_out_edit = GetValue<bool>("default.allow-text-edit", File.allow_out_edit);
+
+#ifdef __linux__
+    const char *tessdata_prefix;
+    if ((tessdata_prefix = getenv("TESSDATA_PREFIX"))) {
+        File.ocr_path = tessdata_prefix;
+    }
+#endif
 }
 
 void Config::LoadThemeFile(const std::string& filename)


### PR DESCRIPTION
This PR:
1. adds flake.nix and flake.lock (tested and installed on NixOS 26.05 Yarara)
2. includes oshot.desktop in the CMake install
3. makes the config use `TESSDATA_PREFIX` by default when trying to resolve `ocr_path`.
4. removes the `ocr-path` definition in the default config, so that environment variable changes can take place normally.
5. includes instructions in README.md for NixOS troubleshooting

Issues:
1. flake.nix doesn't use CMake to install. This doesn't affect the reliability of the flake, but it's a big consideration. The reason CMake isn't used is because it breaks the binary.