### PR TITLE
Update flake.nix and flake.lock for latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,10 @@ jobs:
             glfw \
             tesseract \
             zbar \
-            libappindicator-gtk3
+            libappindicator-gtk3 \
+            wayland-protocols \
+            wayland-utils \
+            wayland
 
       - name: Install dependencies (AppImage)
         if: matrix.target == 'linux-appimage'
@@ -177,7 +180,9 @@ jobs:
             libtiff-dev \
             libwebp-dev \
             libzbar-dev \
-            libappindicator3-dev
+            libappindicator3-dev \
+            libwayland-dev \
+            wayland-protocols
 
       - name: Install dependencies (debian-package)
         if: matrix.target == 'debian-package'
@@ -195,7 +200,9 @@ jobs:
             libtesseract-dev \
             libpng-dev \
             libzbar-dev \
-            libayatana-appindicator3-dev
+            libayatana-appindicator3-dev \
+            libwayland-dev \
+            wayland-protocols
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ imgui.ini
 compile_commands.json
 include/xdg-output-unstable-v1-client-protocol.h
 src/xdg-output-unstable-v1-protocol.c
+
+# Flake
+result

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ AppDir
 .cache
 imgui.ini
 compile_commands.json
+include/xdg-output-unstable-v1-client-protocol.h
+src/xdg-output-unstable-v1-protocol.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #add_compile_options($<$<CONFIG:Debug>:-fno-omit-frame-pointer>)
 #add_link_options($<$<CONFIG:Debug>:-fsanitize=address>)
 
-# GCC/Clang default Release flags already include -O3; this just makes it
-# explicit.
 if(NOT MSVC AND NOT CMAKE_CXX_FLAGS_RELEASE MATCHES "-O")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 endif()
@@ -57,8 +55,7 @@ endfunction()
 # https://github.com/libcpr/cpr/blob/5f475522597b8f3721e2440daddeced7a969f24c/CMakeLists.txt#L39
 # NOTE: definitions are collected into OSHOT_OPTION_DEFINITIONS instead of
 # using add_definitions(), which is directory-scoped and would otherwise leak
-# into every target declared afterward - including vendored third-party
-# libs (fmt, imgui, tray, clip, dylib, nvdialog, tiny-process-library).
+# into every target declared afterward.
 # They're applied to just ${PROJECT_NAME} once it exists (see below).
 set(OSHOT_OPTION_DEFINITIONS "")
 macro(add_option OPTION_NAME OPTION_TEXT OPTION_DEFAULT DEFINE_OPTION)
@@ -92,6 +89,7 @@ endif()
 find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 find_package(glfw3 REQUIRED)
+find_package(OpenGL REQUIRED)
 
 if(TARGET glfw::glfw)
     set(GLFW_TARGET glfw::glfw)
@@ -103,7 +101,6 @@ else()
     message(FATAL_ERROR "GLFW found but no usable CMake target was exported")
 endif()
 
-find_package(OpenGL REQUIRED)
 pkg_check_modules(TESSERACT REQUIRED IMPORTED_TARGET tesseract)
 pkg_check_modules(LEPTONICA REQUIRED IMPORTED_TARGET lept)
 pkg_check_modules(ZBAR REQUIRED IMPORTED_TARGET zbar)
@@ -176,11 +173,6 @@ target_compile_definitions(
     PUBLIC VERSION="${PROJECT_VERSION}" TOML_HEADER_ONLY=0
 )
 
-# oshot's own sources (main.cpp, main_tool_opengl3.cpp) reference
-# globals.cpp's externs directly (g_sock, g_ss_tool, g_config, g_cache, ...),
-# which live in the real oshot_common SHARED library. There's no separate
-# oshot_plugin library anymore (see the note above oshot_common's sources
-# below for why), so linking oshot_common alone is enough.
 target_link_libraries(${PROJECT_NAME} PRIVATE oshot_common)
 
 if(WIN32 AND NOT WINDOWS_CMD)
@@ -273,7 +265,10 @@ if(NOT DISABLE_PLUGINS)
             WINDOWS_EXPORT_ALL_SYMBOLS ON
             POSITION_INDEPENDENT_CODE ON
     )
-    target_include_directories(oshot_common PUBLIC ${CMAKE_SOURCE_DIR}/oshotpm/include)
+    target_include_directories(
+        oshot_common
+        PUBLIC ${CMAKE_SOURCE_DIR}/oshotpm/include
+    )
 endif()
 
 enable_lto(oshot_common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,15 +104,17 @@ endif()
 pkg_check_modules(TESSERACT REQUIRED IMPORTED_TARGET tesseract)
 pkg_check_modules(LEPTONICA REQUIRED IMPORTED_TARGET lept)
 pkg_check_modules(ZBAR REQUIRED IMPORTED_TARGET zbar)
-pkg_check_modules(
-    WAYLAND
-    REQUIRED
-    IMPORTED_TARGET
-    wayland-client
-    wayland-server
-    wayland-egl
-    wayland-cursor
-)
+if(UNIX AND NOT APPLE)
+    pkg_check_modules(
+        WAYLAND
+        REQUIRED
+        IMPORTED_TARGET
+        wayland-client
+        wayland-server
+        wayland-egl
+        wayland-cursor
+    )
+endif()
 
 # Homebrew's lept.pc points Cflags at .../include/leptonica directly (its
 # own convention is `#include <allheaders.h>`), but our code uses
@@ -266,9 +268,6 @@ if(UNIX AND NOT APPLE)
     set(PROTOCOL_SOURCE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROTOCOL_BASE_NAME}-protocol.c
     )
-    set(XDG_OUTPUT_XML
-        "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-output/${PROTOCOL_BASE_NAME}.xml"
-    )
     list(APPEND OSHOT_COMMON_SOURCES src/wl_get_monitors.cpp ${PROTOCOL_SOURCE})
     set_source_files_properties(
         src/wl_get_monitors.cpp
@@ -341,7 +340,7 @@ else()
     )
     target_link_libraries(
         oshot_common
-        PRIVATE ${GIO_LIBRARIES} ${XRANDR_LIBRARIES}
+        PRIVATE ${GIO_LIBRARIES} ${XRANDR_LIBRARIES} PkgConfig::WAYLAND
     )
     target_compile_options(
         oshot_common
@@ -353,6 +352,9 @@ else()
 
     pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
     pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
+    set(XDG_OUTPUT_XML
+        "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-output/${PROTOCOL_BASE_NAME}.xml"
+    )
 
     add_custom_command(
         OUTPUT ${PROTOCOL_HEADER}
@@ -360,7 +362,7 @@ else()
             ${WAYLAND_SCANNER} client-header ${XDG_OUTPUT_XML}
             ${PROTOCOL_HEADER}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        DEPENDS ${PROTOCOL_HEADER}
+        DEPENDS ${XDG_OUTPUT_XML}
         COMMENT "Generating Wayland ${PROTOCOL_BASE_NAME} header"
     )
     add_custom_command(
@@ -368,7 +370,7 @@ else()
         COMMAND
             ${WAYLAND_SCANNER} private-code ${XDG_OUTPUT_XML} ${PROTOCOL_SOURCE}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        DEPENDS ${PROTOCOL_SOURCE}
+        DEPENDS ${XDG_OUTPUT_XML}
         COMMENT "Generating Wayland ${PROTOCOL_BASE_NAME} private code"
     )
     add_custom_target(
@@ -392,7 +394,6 @@ target_link_libraries(
         PkgConfig::TESSERACT
         PkgConfig::LEPTONICA
         PkgConfig::ZBAR
-        PkgConfig::WAYLAND
         OpenGL::GL
         ${GLFW_TARGET}
     PRIVATE Threads::Threads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,17 +104,6 @@ endif()
 pkg_check_modules(TESSERACT REQUIRED IMPORTED_TARGET tesseract)
 pkg_check_modules(LEPTONICA REQUIRED IMPORTED_TARGET lept)
 pkg_check_modules(ZBAR REQUIRED IMPORTED_TARGET zbar)
-if(UNIX AND NOT APPLE)
-    pkg_check_modules(
-        WAYLAND
-        REQUIRED
-        IMPORTED_TARGET
-        wayland-client
-        wayland-server
-        wayland-egl
-        wayland-cursor
-    )
-endif()
 
 # Homebrew's lept.pc points Cflags at .../include/leptonica directly (its
 # own convention is `#include <allheaders.h>`), but our code uses
@@ -138,6 +127,15 @@ if(UNIX AND NOT APPLE)
     pkg_check_modules(XRANDR REQUIRED xrandr)
     pkg_check_modules(GTK REQUIRED gtk+-3.0)
     pkg_check_modules(DBUS REQUIRED dbus-1)
+    pkg_check_modules(
+        WAYLAND
+        REQUIRED
+        IMPORTED_TARGET
+        wayland-client
+        wayland-server
+        wayland-egl
+        wayland-cursor
+    )
 endif()
 
 # -----------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,15 @@ endif()
 pkg_check_modules(TESSERACT REQUIRED IMPORTED_TARGET tesseract)
 pkg_check_modules(LEPTONICA REQUIRED IMPORTED_TARGET lept)
 pkg_check_modules(ZBAR REQUIRED IMPORTED_TARGET zbar)
+pkg_check_modules(
+    WAYLAND
+    REQUIRED
+    IMPORTED_TARGET
+    wayland-client
+    wayland-server
+    wayland-egl
+    wayland-cursor
+)
 
 # Homebrew's lept.pc points Cflags at .../include/leptonica directly (its
 # own convention is `#include <allheaders.h>`), but our code uses
@@ -142,13 +151,12 @@ add_executable(
 enable_lto(${PROJECT_NAME})
 
 set(VERSION_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/version.h)
+set(VERSION_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generateVersion.sh)
 add_custom_command(
     OUTPUT ${VERSION_HEADER}
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generateVersion.sh
+    COMMAND ${VERSION_SCRIPT}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    DEPENDS
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/version.h.in
-        ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generateVersion.sh
+    DEPENDS ${VERSION_HEADER}.in ${VERSION_SCRIPT}
     COMMENT "Generating version header"
 )
 add_custom_target(generate_version DEPENDS ${VERSION_HEADER})
@@ -250,6 +258,25 @@ if(NOT DISABLE_PLUGINS)
     )
 endif()
 
+if(UNIX AND NOT APPLE)
+    set(PROTOCOL_BASE_NAME xdg-output-unstable-v1)
+    set(PROTOCOL_HEADER
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROTOCOL_BASE_NAME}-client-protocol.h
+    )
+    set(PROTOCOL_SOURCE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROTOCOL_BASE_NAME}-protocol.c
+    )
+    set(XDG_OUTPUT_XML
+        "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-output/${PROTOCOL_BASE_NAME}.xml"
+    )
+    list(APPEND OSHOT_COMMON_SOURCES src/wl_get_monitors.cpp ${PROTOCOL_SOURCE})
+    set_source_files_properties(
+        src/wl_get_monitors.cpp
+        ${PROTOCOL_SOURCE}
+        PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter"
+    )
+endif()
+
 add_library(oshot_common ${OSHOT_COMMON_LIB_TYPE} ${OSHOT_COMMON_SOURCES})
 
 if(OSHOT_OPTION_DEFINITIONS)
@@ -300,7 +327,7 @@ elseif(APPLE)
 else()
     target_include_directories(
         oshot_common
-        PRIVATE ${APPINDICATOR_INCLUDE_DIRS}
+        PRIVATE ${APPINDICATOR_INCLUDE_DIRS} ${WAYLAND_INCLUDE_DIRS}
     )
     target_compile_options(oshot_common PRIVATE ${APPINDICATOR_CFLAGS_OTHER})
 
@@ -318,8 +345,37 @@ else()
     )
     target_compile_options(
         oshot_common
-        PRIVATE ${GIO_CFLAGS_OTHER} ${XRANDR_CFLAGS_OTHER}
+        PRIVATE
+            ${GIO_CFLAGS_OTHER}
+            ${XRANDR_CFLAGS_OTHER}
+            ${WAYLAND_CFLAGS_OTHER}
     )
+
+    pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
+    pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
+
+    add_custom_command(
+        OUTPUT ${PROTOCOL_HEADER}
+        COMMAND
+            ${WAYLAND_SCANNER} client-header ${XDG_OUTPUT_XML}
+            ${PROTOCOL_HEADER}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS ${PROTOCOL_HEADER}
+        COMMENT "Generating Wayland ${PROTOCOL_BASE_NAME} header"
+    )
+    add_custom_command(
+        OUTPUT ${PROTOCOL_SOURCE}
+        COMMAND
+            ${WAYLAND_SCANNER} private-code ${XDG_OUTPUT_XML} ${PROTOCOL_SOURCE}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS ${PROTOCOL_SOURCE}
+        COMMENT "Generating Wayland ${PROTOCOL_BASE_NAME} private code"
+    )
+    add_custom_target(
+        generate_protocol
+        DEPENDS ${PROTOCOL_HEADER} ${PROTOCOL_SOURCE}
+    )
+    add_dependencies(oshot_common generate_protocol)
 endif()
 
 target_link_libraries(
@@ -336,6 +392,7 @@ target_link_libraries(
         PkgConfig::TESSERACT
         PkgConfig::LEPTONICA
         PkgConfig::ZBAR
+        PkgConfig::WAYLAND
         OpenGL::GL
         ${GLFW_TARGET}
     PRIVATE Threads::Threads

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-
-    oshot-src = {
-      url = "github:Toni500github/oshot";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, oshot-src }:
+  outputs = { self, nixpkgs }:
     let
       supportedSystems = [ "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
@@ -26,7 +21,7 @@
             pname = "oshot";
             version = "0.5.0-rc1";
 
-            src = oshot-src;
+            src = ./.;
 
             nativeBuildInputs = with pkgs; [
               cmake
@@ -34,6 +29,7 @@
               pkg-config
               git
               wrapGAppsHook3
+              wayland-scanner
             ];
 
             buildInputs = with pkgs; [
@@ -52,11 +48,16 @@
               libsysprof-capture
               libXdmcp
               zenity
+              pcre2
             ];
 
             # Initialize git AND add a tag so `git describe` works
             preConfigure = ''
-              git init
+              export SOURCE_DATE_EPOCH=1
+              export GIT_AUTHOR_DATE="1970-01-01T00:00:01Z"
+              export GIT_COMMENTOR_DATE="1970-01-01T00:00:01Z"
+
+              git init -b nix-build
               git config user.name "Nix"
               git config user.email "nix@localhost"
               git add .
@@ -81,5 +82,15 @@
 
           default = self.packages.${system}.oshot;
         });
+
+      nixosModules.default = { config, lib, pkgs, ... }: {
+        options.programs.oshot.enable = lib.mkEnableOption "oshot text extraction and screenshot tool";
+
+        config = lib.mkIf config.programs.oshot.enable {
+          environment.systemPackages = [ 
+            self.packages.${pkgs.system}.oshot
+          ];  
+        };
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,28 +3,83 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    oshot-src = {
+      url = "github:Toni500github/oshot";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs }: {
-    packages.x86_64-linux.oshot =
-      with import nixpkgs { system = "x86_64-linux"; };
-      stdenv.mkDerivation {
-        name = "oshot";
-        src = self;
-        nativeBuildInputs = [ cmake gnumake pkg-config git ];
-        buildInputs = [ glfw3 leptonica libx11.dev tesseract zbar.dev libappindicator-gtk3.dev dbus.dev systemd.dev libsysprof-capture pcre2.dev libxdmcp.dev libuuid.dev libselinux.dev libsepol.dev libthai.dev libdatrie.dev libdeflate lerc.dev xz.dev zstd.dev libwebp libxkbcommon.dev libepoxy.dev libxtst giflib ];
-        configurePhase = ''
-          cmake -DCMAKE_BUILD_PREFIX=/usr -DDEBUG=0 -G "Unix Makefiles" -B build -S .
-        '';
-        buildPhase = ''
-          cmake --build build -j$(nproc)
-        '';
-        installPhase = ''
-          install -Dm755 build/oshot $out/bin/oshot
-          install -Dm644 oshot.desktop $out/share/applications/oshot.desktop
-          install -Dm644 LICENSE $out/share/licenses/oshot/LICENSE
-        '';
-      };
-    packages.x86_64-linux.default = self.packages.x86_64-linux.oshot;
-  };
+  outputs = { self, nixpkgs, oshot-src }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          oshot = pkgs.stdenv.mkDerivation {
+            pname = "oshot";
+            version = "0.5.0-rc1";
+
+            src = oshot-src;
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              gnumake
+              pkg-config
+              git
+              wrapGAppsHook3
+            ];
+
+            buildInputs = with pkgs; [
+              glfw3
+              leptonica
+              tesseract
+              zbar
+              gtk3
+              libappindicator-gtk3
+              dbus
+              systemd
+              libX11
+              libXtst
+              giflib
+              libwebp
+              libsysprof-capture
+              libXdmcp
+              zenity
+            ];
+
+            # Initialize git AND add a tag so `git describe` works
+            preConfigure = ''
+              git init
+              git config user.name "Nix"
+              git config user.email "nix@localhost"
+              git add .
+              git commit -m "dummy commit for build"
+              git tag -a v0.1.0 -m "v0.1.0"
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              install -Dm755 oshot $out/bin/oshot
+              if [ -f oshot.desktop ]; then
+                install -Dm644 oshot.desktop $out/share/applications/oshot.desktop
+              fi
+              if [ -f LICENSE ]; then
+                install -Dm644 LICENSE $out/share/licenses/oshot/LICENSE
+              fi
+
+              runHook postInstall
+            '';
+          };
+
+          default = self.packages.${system}.oshot;
+        });
+    };
 }

--- a/include/screen_capture.hpp
+++ b/include/screen_capture.hpp
@@ -33,6 +33,10 @@
 
 #include "util.hpp"
 
+#if OSHOT_LINUX
+#  include <wayland-client.h>
+#endif
+
 struct region_t
 {
     int x{};
@@ -50,6 +54,16 @@ struct capture_result_t
     std::span<const uint8_t> view() const { return data; }
     std::span<uint8_t>       view() { return data; }
 };
+
+#if OSHOT_LINUX
+struct monitor_t
+{
+    char       name[64];
+    region_t   geo;
+    bool       done;
+    wl_output* handle = nullptr;
+};
+#endif
 
 enum class SessionType
 {

--- a/include/screen_capture.hpp
+++ b/include/screen_capture.hpp
@@ -56,7 +56,8 @@ struct monitor_t
     char     name[64];
     region_t geo;
     bool     done;
-    void*    handle = nullptr;  // wl_output*
+    void*    handle    = nullptr;  // struct wl_output*
+    int32_t  transform = 0;        // WL_OUTPUT_TRANSFORM_* value
 };
 
 enum class SessionType
@@ -76,6 +77,7 @@ Result<capture_result_t> capture_full_screen_windows();
 Result<capture_result_t> capture_full_screen_macos();
 
 SessionType              get_session_type();
+capture_result_t         rotate_rgba(const capture_result_t& src, int quarter_turns_cw);
 Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
                                          const std::deque<region_t>& monitors,
                                          const region_t&             target);

--- a/include/screen_capture.hpp
+++ b/include/screen_capture.hpp
@@ -27,6 +27,7 @@
 #define _SCREEN_CAPTURE_HPP_
 
 #include <cstdint>
+#include <deque>
 #include <span>
 #include <vector>
 
@@ -66,6 +67,9 @@ Result<capture_result_t> capture_full_screen_spectacle();
 Result<capture_result_t> capture_full_screen_windows();
 Result<capture_result_t> capture_full_screen_macos();
 
-SessionType get_session_type();
+SessionType              get_session_type();
+Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
+                                         const std::deque<region_t>& monitors,
+                                         const region_t&             target);
 
 #endif  // !_SCREEN_CAPTURE_HPP_

--- a/include/screen_capture.hpp
+++ b/include/screen_capture.hpp
@@ -33,10 +33,6 @@
 
 #include "util.hpp"
 
-#if OSHOT_LINUX
-#  include <wayland-client.h>
-#endif
-
 struct region_t
 {
     int x{};
@@ -55,15 +51,13 @@ struct capture_result_t
     std::span<uint8_t>       view() { return data; }
 };
 
-#if OSHOT_LINUX
 struct monitor_t
 {
-    char       name[64];
-    region_t   geo;
-    bool       done;
-    wl_output* handle = nullptr;
+    char     name[64];
+    region_t geo;
+    bool     done;
+    void*    handle = nullptr;  // wl_output*
 };
-#endif
 
 enum class SessionType
 {

--- a/include/screen_capture.hpp
+++ b/include/screen_capture.hpp
@@ -37,8 +37,8 @@ struct region_t
 {
     int x{};
     int y{};
-    int width{};
-    int height{};
+    int w{};
+    int h{};
 };
 
 struct capture_result_t

--- a/include/screenshot_tool.hpp
+++ b/include/screenshot_tool.hpp
@@ -319,7 +319,7 @@ public:
     Result<>             StartWindow();
     Result<ImTextureRef> CreateTexture(void* tex, std::span<const uint8_t> data, int w, int h);
     bool                 OpenImage(const std::string& path);
-    Result<>             CropToOutput(const std::deque<region_t>& layout, const monitor_t& target);
+    Result<>             CropToOutput(const std::deque<region_t>& layout, const monitor_t& target, int transform = 0);
     bool                 IsActive() const { return m_state != ToolState::Idle; }
     capture_result_t&    GetRawScreenshot() { return m_screenshot; }
     void                 SetBackendTexture(void* tex) { m_texture_id._TexID = static_cast<ImTextureID>(size_t(tex)); }

--- a/include/screenshot_tool.hpp
+++ b/include/screenshot_tool.hpp
@@ -121,6 +121,7 @@ enum class SubWindow : size_t
     ManagePlugins,
     UninstallPlugins,
     Logs,
+    OutputMenuSelection,
     COUNT
 };
 
@@ -318,6 +319,7 @@ public:
     Result<>             StartWindow();
     Result<ImTextureRef> CreateTexture(void* tex, std::span<const uint8_t> data, int w, int h);
     bool                 OpenImage(const std::string& path);
+    Result<>             CropToOutput(const std::deque<region_t>& layout, const region_t& target);
     bool                 IsActive() const { return m_state != ToolState::Idle; }
     capture_result_t&    GetRawScreenshot() { return m_screenshot; }
     void                 SetBackendTexture(void* tex) { m_texture_id._TexID = static_cast<ImTextureID>(size_t(tex)); }
@@ -431,6 +433,7 @@ private:
 
     std::function<void(SavingOp, const capture_result_t&, ImageExt)> m_on_complete;
 
+    SessionType                                    m_session;
     std::string                                    m_last_scanned_ocr_path;
     GeneralContext<SubWindow>                      m_show_window;
     GeneralContext<CurrentAction>                  m_current_actions;
@@ -479,6 +482,8 @@ private:
     void DrawPreferencesWindow();
     void DrawDownloadOCRWindow();
     void DrawLogsWindow();
+
+    void DrawOutputMenuSelection();
 
 #ifndef DISABLE_PLUGINS
     void DrawManagePluginsWindow();

--- a/include/screenshot_tool.hpp
+++ b/include/screenshot_tool.hpp
@@ -433,6 +433,7 @@ private:
 
     std::function<void(SavingOp, const capture_result_t&, ImageExt)> m_on_complete;
 
+    std::deque<monitor_t>                          m_wayland_monitors;
     SessionType                                    m_session;
     std::string                                    m_last_scanned_ocr_path;
     GeneralContext<SubWindow>                      m_show_window;

--- a/include/screenshot_tool.hpp
+++ b/include/screenshot_tool.hpp
@@ -319,7 +319,7 @@ public:
     Result<>             StartWindow();
     Result<ImTextureRef> CreateTexture(void* tex, std::span<const uint8_t> data, int w, int h);
     bool                 OpenImage(const std::string& path);
-    Result<>             CropToOutput(const std::deque<region_t>& layout, const region_t& target);
+    Result<>             CropToOutput(const std::deque<region_t>& layout, const monitor_t& target);
     bool                 IsActive() const { return m_state != ToolState::Idle; }
     capture_result_t&    GetRawScreenshot() { return m_screenshot; }
     void                 SetBackendTexture(void* tex) { m_texture_id._TexID = static_cast<ImTextureID>(size_t(tex)); }

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -251,6 +251,8 @@ constexpr E toe(T n) noexcept
 struct capture_result_t;
 struct ImVec4;
 struct ImGuiIO;
+struct GLFWmonitor;
+struct GLFWvidmode;
 enum class ImageExt;
 // I'm not including <gtk/gtk.h> just for a couple of functions
 extern "C" {
@@ -390,10 +392,15 @@ Result<capture_result_t> load_image_rgba(const std::string& path);
 Result<std::string>      get_config_image_out_fmt();
 Result<>                 save_image(SavingOp op, const capture_result_t& img, ImageExt ext);
 
-void minimize_window();
-void maximize_window();
-void extern_glfwTerminate();
-void extern_glfwSwapInterval(int v);
+void               minimize_window();
+void               maximize_window();
+void               extern_glfwTerminate();
+void               extern_glfwSwapInterval(int v);
+GLFWmonitor**      extern_glfwGetMonitors(int* count);
+void               extern_glfwGetMonitorPos(GLFWmonitor* mon, int* x, int* y);
+void               extern_glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int* heightMM);
+const GLFWvidmode* extern_glfwGetVideoMode(GLFWmonitor* mon);
+const char*        extern_glfwGetMonitorName(GLFWmonitor* mon);
 
 byte_units_t auto_divide_bytes(const double num, const std::uint16_t base, const std::string_view maxprefix = "");
 byte_units_t divide_bytes(const double num, const std::string_view prefix);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -251,8 +251,6 @@ constexpr E toe(T n) noexcept
 struct capture_result_t;
 struct ImVec4;
 struct ImGuiIO;
-struct GLFWmonitor;
-struct GLFWvidmode;
 enum class ImageExt;
 // I'm not including <gtk/gtk.h> just for a couple of functions
 extern "C" {
@@ -392,15 +390,10 @@ Result<capture_result_t> load_image_rgba(const std::string& path);
 Result<std::string>      get_config_image_out_fmt();
 Result<>                 save_image(SavingOp op, const capture_result_t& img, ImageExt ext);
 
-void               minimize_window();
-void               maximize_window();
-void               extern_glfwTerminate();
-void               extern_glfwSwapInterval(int v);
-GLFWmonitor**      extern_glfwGetMonitors(int* count);
-void               extern_glfwGetMonitorPos(GLFWmonitor* mon, int* x, int* y);
-void               extern_glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int* heightMM);
-const GLFWvidmode* extern_glfwGetVideoMode(GLFWmonitor* mon);
-const char*        extern_glfwGetMonitorName(GLFWmonitor* mon);
+void minimize_window();
+void maximize_window();
+void extern_glfwTerminate();
+void extern_glfwSwapInterval(int v);
 
 byte_units_t auto_divide_bytes(const double num, const std::uint16_t base, const std::string_view maxprefix = "");
 byte_units_t divide_bytes(const double num, const std::string_view prefix);

--- a/src/main_tool_metal.mm
+++ b/src/main_tool_metal.mm
@@ -53,8 +53,13 @@ void glfw_error_callback(int error, const char* description);
 void glfw_drop_callback(GLFWwindow*, int count, const char** paths);
 void register_window_callbacks(void (*minimize_fn)(),
                                void (*maximize_fn)(),
-                               void (*terminate_fn)(),
-                               void (*swap_interval_fn)(int));
+                               void (*_extern_glfwTerminate)(),
+                               void (*_extern_glfwSwapInterval)(int),
+                               GLFWmonitor** (*_extern_glfwGetMonitors)(int*),
+                               void (*_extern_glfwGetMonitorPos)(GLFWmonitor*, int*, int*),
+                               void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*),
+                               const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*),
+                               const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*));
 
 GLFWwindow* window = nullptr;
 
@@ -88,7 +93,15 @@ static id<MTLTexture> create_metal_texture(id<MTLDevice> device, const uint8_t* 
 
 int run_main_tool()
 {
-    register_window_callbacks(minimize_window_, maximize_window_, glfwTerminate, glfwSwapInterval);
+    register_window_callbacks(minimize_window_,
+                              maximize_window_,
+                              glfwTerminate,
+                              glfwSwapInterval,
+                              glfwGetMonitors,
+                              glfwGetMonitorPos,
+                              glfwGetMonitorPhysicalSize,
+                              glfwGetVideoMode,
+                              glfwGetMonitorName);
     id<MTLDevice> device;
 
     // vsync is controlled via the CAMetalLayer's displaySyncEnabled property instead.

--- a/src/main_tool_metal.mm
+++ b/src/main_tool_metal.mm
@@ -54,12 +54,7 @@ void glfw_drop_callback(GLFWwindow*, int count, const char** paths);
 void register_window_callbacks(void (*minimize_fn)(),
                                void (*maximize_fn)(),
                                void (*_extern_glfwTerminate)(),
-                               void (*_extern_glfwSwapInterval)(int),
-                               GLFWmonitor** (*_extern_glfwGetMonitors)(int*),
-                               void (*_extern_glfwGetMonitorPos)(GLFWmonitor*, int*, int*),
-                               void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*),
-                               const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*),
-                               const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*));
+                               void (*_extern_glfwSwapInterval)(int));
 
 GLFWwindow* window = nullptr;
 
@@ -93,15 +88,7 @@ static id<MTLTexture> create_metal_texture(id<MTLDevice> device, const uint8_t* 
 
 int run_main_tool()
 {
-    register_window_callbacks(minimize_window_,
-                              maximize_window_,
-                              glfwTerminate,
-                              glfwSwapInterval,
-                              glfwGetMonitors,
-                              glfwGetMonitorPos,
-                              glfwGetMonitorPhysicalSize,
-                              glfwGetVideoMode,
-                              glfwGetMonitorName);
+    register_window_callbacks(minimize_window_, maximize_window_, glfwTerminate, glfwSwapInterval);
     id<MTLDevice> device;
 
     // vsync is controlled via the CAMetalLayer's displaySyncEnabled property instead.

--- a/src/main_tool_opengl3.cpp
+++ b/src/main_tool_opengl3.cpp
@@ -54,12 +54,7 @@ void glfw_drop_callback(GLFWwindow*, int count, const char** paths);
 void register_window_callbacks(void (*minimize_fn)(),
                                void (*maximize_fn)(),
                                void (*_extern_glfwTerminate)(),
-                               void (*_extern_glfwSwapInterval)(int),
-                               GLFWmonitor** (*_extern_glfwGetMonitors)(int*),
-                               void (*_extern_glfwGetMonitorPos)(GLFWmonitor*, int*, int*),
-                               void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*),
-                               const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*),
-                               const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*));
+                               void (*_extern_glfwSwapInterval)(int));
 
 // Returns the GLFW monitor that currently contains the cursor.
 // Falls back to the primary monitor if the cursor position cannot be
@@ -130,15 +125,7 @@ static void maximize_window_()
 
 int run_main_tool()
 {
-    register_window_callbacks(minimize_window_,
-                              maximize_window_,
-                              glfwTerminate,
-                              glfwSwapInterval,
-                              glfwGetMonitors,
-                              glfwGetMonitorPos,
-                              glfwGetMonitorPhysicalSize,
-                              glfwGetVideoMode,
-                              glfwGetMonitorName);
+    register_window_callbacks(minimize_window_, maximize_window_, glfwTerminate, glfwSwapInterval);
 
     // Setup Screenshot Tool
     // Calling it before starting the window so that

--- a/src/main_tool_opengl3.cpp
+++ b/src/main_tool_opengl3.cpp
@@ -53,8 +53,13 @@ void glfw_error_callback(int i_error, const char* description);
 void glfw_drop_callback(GLFWwindow*, int count, const char** paths);
 void register_window_callbacks(void (*minimize_fn)(),
                                void (*maximize_fn)(),
-                               void (*terminate_fn)(),
-                               void (*swap_interval_fn)(int));
+                               void (*_extern_glfwTerminate)(),
+                               void (*_extern_glfwSwapInterval)(int),
+                               GLFWmonitor** (*_extern_glfwGetMonitors)(int*),
+                               void (*_extern_glfwGetMonitorPos)(GLFWmonitor*, int*, int*),
+                               void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*),
+                               const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*),
+                               const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*));
 
 // Returns the GLFW monitor that currently contains the cursor.
 // Falls back to the primary monitor if the cursor position cannot be
@@ -124,7 +129,15 @@ static void maximize_window_()
 
 int run_main_tool()
 {
-    register_window_callbacks(minimize_window_, maximize_window_, glfwTerminate, glfwSwapInterval);
+    register_window_callbacks(minimize_window_,
+                              maximize_window_,
+                              glfwTerminate,
+                              glfwSwapInterval,
+                              glfwGetMonitors,
+                              glfwGetMonitorPos,
+                              glfwGetMonitorPhysicalSize,
+                              glfwGetVideoMode,
+                              glfwGetMonitorName);
 
     // Setup Screenshot Tool
     // Calling it before starting the window so that
@@ -181,7 +194,7 @@ int run_main_tool()
 
 #  if !DEBUG
     // Don't make the window actually fullscreen if debug build
-    // this because on windows it hanged in gdb and everytime had to restart the VM
+    // this because on Windows it hanged in gdb and everytime I had to restart the VM
     glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);  // Borderless
     glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);    // Always on top
     glfwWindowHint(GLFW_FOCUSED, GLFW_TRUE);

--- a/src/main_tool_opengl3.cpp
+++ b/src/main_tool_opengl3.cpp
@@ -46,6 +46,8 @@
 #    include <X11/Xlib.h>
 #  endif
 
+using namespace std::chrono_literals;
+
 GLFWwindow* window = nullptr;
 
 void apply_imgui_theme();
@@ -208,6 +210,19 @@ int run_main_tool()
     glfwMakeContextCurrent(window);
     glfwSetDropCallback(window, glfw_drop_callback);
     glfwSwapInterval(1);  // Enable vsync
+
+    // Wayland compositors negotiate final toplevel size via configure events
+    // after creation (window rules, panel/exclusive-zone avoidance, etc.).
+    // Instant mode's near-immediate first frame can render before that lands,
+    // using a stale framebuffer size. Give it a few polls to settle.
+    if (get_session_type() == SessionType::Wayland)
+    {
+        for (int i = 0; i < 5; ++i)
+        {
+            glfwPollEvents();
+            std::this_thread::sleep_for(20ms);
+        }
+    }
 
     g_scr_w = mode->width;
     g_scr_h = mode->height;

--- a/src/main_tool_opengl3.cpp
+++ b/src/main_tool_opengl3.cpp
@@ -92,6 +92,7 @@ static GLFWmonitor* get_monitor_at_cursor()
     }
 #  endif
 
+    cursor_ok = false;
     if (!cursor_ok)
         return glfwGetPrimaryMonitor();
 

--- a/src/main_tool_opengl3.cpp
+++ b/src/main_tool_opengl3.cpp
@@ -87,7 +87,6 @@ static GLFWmonitor* get_monitor_at_cursor()
     }
 #  endif
 
-    cursor_ok = false;
     if (!cursor_ok)
         return glfwGetPrimaryMonitor();
 

--- a/src/screen_capture.cpp
+++ b/src/screen_capture.cpp
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -115,13 +116,13 @@ Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
         return Err("No monitor list provided");
 
     int min_x = monitors[0].x, min_y = monitors[0].y;
-    int max_x = monitors[0].x + monitors[0].width, max_y = monitors[0].y + monitors[0].height;
+    int max_x = monitors[0].x + monitors[0].w, max_y = monitors[0].y + monitors[0].h;
     for (const region_t& m : monitors)
     {
         min_x = std::min(min_x, m.x);
         min_y = std::min(min_y, m.y);
-        max_x = std::max(max_x, m.x + m.width);
-        max_y = std::max(max_y, m.y + m.height);
+        max_x = std::max(max_x, m.x + m.w);
+        max_y = std::max(max_y, m.y + m.h);
     }
     const int layout_w = max_x - min_x;
     const int layout_h = max_y - min_y;
@@ -133,8 +134,8 @@ Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
 
     const int crop_x = std::clamp(int(std::lround((target.x - min_x) * scale_x)), 0, full.w);
     const int crop_y = std::clamp(int(std::lround((target.y - min_y) * scale_y)), 0, full.h);
-    const int crop_w = std::clamp(int(std::lround(target.width * scale_x)), 0, full.w - crop_x);
-    const int crop_h = std::clamp(int(std::lround(target.height * scale_y)), 0, full.h - crop_y);
+    const int crop_w = std::clamp(int(std::lround(target.w * scale_x)), 0, full.w - crop_x);
+    const int crop_h = std::clamp(int(std::lround(target.h * scale_y)), 0, full.h - crop_y);
 
     if (crop_w <= 0 || crop_h <= 0)
         return Err("Computed crop rect is empty");
@@ -204,16 +205,15 @@ Result<capture_result_t> capture_full_screen_portal();
 // Query the geometry of the monitor under the cursor via Xlib + XRandR.
 // Works on native X11 and on any Wayland compositor that runs XWayland.
 // Returns false if X is unavailable (pure Wayland without XWayland).
-static bool get_cursor_monitor_xrandr(Display* display, int& out_x, int& out_y, int& out_w, int& out_h)
+static std::optional<region_t> get_cursor_monitor_xrandr(Display* display)
 {
-    return false;
     const char* disp_env = std::getenv("DISPLAY");
     if (!disp_env || disp_env[0] == '\0')
-        return false;
+        return std::nullopt;
 
     Display* dpy = display ? display : XOpenDisplay(disp_env);
     if (!dpy)
-        return false;
+        return std::nullopt;
 
     // Query the cursor position so we know which monitor the user is on
     Window       root = DefaultRootWindow(dpy);
@@ -225,15 +225,16 @@ static bool get_cursor_monitor_xrandr(Display* display, int& out_x, int& out_y, 
     int             nmon     = 0;
     XRRMonitorInfo* monitors = XRRGetMonitors(dpy, root, True, &nmon);
 
-    bool found = false;
+    region_t mon_size;
+    bool     found = false;
     if (monitors && nmon > 0)
     {
         // Default to first monitor in case the cursor position is ambiguous
-        out_x = monitors[0].x;
-        out_y = monitors[0].y;
-        out_w = monitors[0].width;
-        out_h = monitors[0].height;
-        found = true;
+        mon_size.x = monitors[0].x;
+        mon_size.y = monitors[0].y;
+        mon_size.w = monitors[0].width;
+        mon_size.h = monitors[0].height;
+        found      = true;
 
         debug("Found {} monitor{}", nmon, nmon > 1 ? "s" : "");
         for (int i = 0; i < nmon; ++i)
@@ -243,10 +244,10 @@ static bool get_cursor_monitor_xrandr(Display* display, int& out_x, int& out_y, 
             const int mw = monitors[i].width, mh = monitors[i].height;
             if (root_x >= mx && root_x < mx + mw && root_y >= my && root_y < my + mh)
             {
-                out_x = mx;
-                out_y = my;
-                out_w = mw;
-                out_h = mh;
+                mon_size.x = mx;
+                mon_size.y = my;
+                mon_size.w = mw;
+                mon_size.h = mh;
                 debug("XRandR capturing: monitor {}x{}+{}+{} (cursor at {},{}) ", mw, mh, mx, my, root_x, root_y);
                 break;
             }
@@ -256,7 +257,10 @@ static bool get_cursor_monitor_xrandr(Display* display, int& out_x, int& out_y, 
 
     if (!display)
         XCloseDisplay(dpy);
-    return found;
+
+    if (found)
+        return mon_size;
+    return std::nullopt;
 }
 
 static std::vector<uint8_t> ximage_to_rgba(XImage* image, int width, int height)
@@ -312,25 +316,27 @@ Result<capture_result_t> capture_full_screen_x11()
 
     Window root = DefaultRootWindow(display);
 
-    int capture_x = 0, capture_y = 0;
-    int capture_w = 0, capture_h = 0;
-
-    if (!get_cursor_monitor_xrandr(display, capture_x, capture_y, capture_w, capture_h))
+    region_t capture{ 0 };
+    if (std::optional<region_t> op_capture = get_cursor_monitor_xrandr(display))
+    {
+        capture = std::move(*op_capture);
+    }
+    else
     {
         // Fall back to root window dimensions (old single-monitor behavior)
         spdlog::warn("XRandR returned no monitors, falling back to root window size");
         XWindowAttributes attrs;
         XGetWindowAttributes(display, root, &attrs);
-        capture_w = attrs.width;
-        capture_h = attrs.height;
+        capture.w = attrs.width;
+        capture.h = attrs.height;
     }
 
     XImage* image = XGetImage(display,
                               root,
-                              capture_x,
-                              capture_y,
-                              static_cast<unsigned int>(capture_w),
-                              static_cast<unsigned int>(capture_h),
+                              capture.x,
+                              capture.y,
+                              static_cast<unsigned int>(capture.w),
+                              static_cast<unsigned int>(capture.h),
                               AllPlanes,
                               ZPixmap);
     if (!image)
@@ -340,9 +346,9 @@ Result<capture_result_t> capture_full_screen_x11()
         return capture_full_screen_portal();
     }
 
-    result.data = ximage_to_rgba(image, capture_w, capture_h);
-    result.w    = capture_w;
-    result.h    = capture_h;
+    result.data = ximage_to_rgba(image, capture.w, capture.h);
+    result.w    = capture.w;
+    result.h    = capture.h;
 
     XDestroyImage(image);
     XCloseDisplay(display);
@@ -630,33 +636,33 @@ Result<capture_result_t> capture_full_screen_portal()
     // The portal always captures the full virtual desktop on multi-monitor
     // setups. Crop down to the monitor that contains the cursor.
     // XRandR works on native X11 and on KDE/GNOME Wayland via XWayland.
+    std::optional<region_t> op_mon = get_cursor_monitor_xrandr(nullptr);
+    if (op_mon && (st.cap.w > op_mon->w || st.cap.h > op_mon->h))
     {
-        int mx = 0, my = 0, mw = 0, mh = 0;
-        if (get_cursor_monitor_xrandr(nullptr, mx, my, mw, mh) && (st.cap.w > mw || st.cap.h > mh))
+        region_t m = std::move(*op_mon);
+        debug("Portal: got monitor with xrandr at cursor position");
+        debug("Portal: cropping {}x{} capture to monitor {}x{}+{}+{}", st.cap.w, st.cap.h, m.w, m.h, m.x, m.y);
+
+        const int x0    = std::max(0, m.x);
+        const int y0    = std::max(0, m.y);
+        const int x1    = std::min(st.cap.w, m.x + m.w);
+        const int y1    = std::min(st.cap.h, m.y + m.h);
+        const int new_w = x1 - x0;
+        const int new_h = y1 - y0;
+
+        if (new_w > 0 && new_h > 0)
         {
-            debug("Portal: cropping {}x{} capture to monitor {}x{}+{}+{}", st.cap.w, st.cap.h, mw, mh, mx, my);
-
-            const int x0    = std::max(0, mx);
-            const int y0    = std::max(0, my);
-            const int x1    = std::min(st.cap.w, mx + mw);
-            const int y1    = std::min(st.cap.h, my + mh);
-            const int new_w = x1 - x0;
-            const int new_h = y1 - y0;
-
-            if (new_w > 0 && new_h > 0)
+            const int            src_stride = st.cap.w;
+            std::vector<uint8_t> cropped(size_t(new_w) * new_h * 4);
+            for (int row = 0; row < new_h; ++row)
             {
-                const int            src_stride = st.cap.w;
-                std::vector<uint8_t> cropped(size_t(new_w) * new_h * 4);
-                for (int row = 0; row < new_h; ++row)
-                {
-                    const uint8_t* src = st.cap.data.data() + (size_t(y0 + row) * src_stride + x0) * 4;
-                    uint8_t*       dst = cropped.data() + size_t(row) * new_w * 4;
-                    std::memcpy(dst, src, size_t(new_w) * 4);
-                }
-                st.cap.data = std::move(cropped);
-                st.cap.w    = new_w;
-                st.cap.h    = new_h;
+                const uint8_t* src = st.cap.data.data() + (size_t(y0 + row) * src_stride + x0) * 4;
+                uint8_t*       dst = cropped.data() + size_t(row) * new_w * 4;
+                std::memcpy(dst, src, size_t(new_w) * 4);
             }
+            st.cap.data = std::move(cropped);
+            st.cap.w    = new_w;
+            st.cap.h    = new_h;
         }
     }
 

--- a/src/screen_capture.cpp
+++ b/src/screen_capture.cpp
@@ -165,6 +165,7 @@ Result<capture_result_t> capture_full_screen_portal();
 // Returns false if X is unavailable (pure Wayland without XWayland).
 static bool get_cursor_monitor_xrandr(Display* display, int& out_x, int& out_y, int& out_w, int& out_h)
 {
+    return false;
     const char* disp_env = std::getenv("DISPLAY");
     if (!disp_env || disp_env[0] == '\0')
         return false;

--- a/src/screen_capture.cpp
+++ b/src/screen_capture.cpp
@@ -157,6 +157,39 @@ Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
     return Ok(std::move(out));
 }
 
+// Rotates an RGBA buffer by a multiple of 90 degrees clockwise.
+// 90/270 swap width and height; 180 doesn't. Used to correct crop_to_monitor()'s
+// output for outputs with a non-zero wl_output transform (rotated monitors),
+// since the compositor's combined capture buffer doesn't pre-rotate per-output
+// content the way logical geometry implies it should.
+capture_result_t rotate_rgba(const capture_result_t& src, int quarter_turns_cw)
+{
+    quarter_turns_cw = ((quarter_turns_cw % 4) + 4) % 4;
+    if (quarter_turns_cw == 0)
+        return src;
+
+    capture_result_t out;
+    out.w = (quarter_turns_cw % 2 == 0) ? src.w : src.h;
+    out.h = (quarter_turns_cw % 2 == 0) ? src.h : src.w;
+    out.data.resize(size_t(out.w) * out.h * 4);
+
+    for (int y = 0; y < src.h; ++y)
+    {
+        for (int x = 0; x < src.w; ++x)
+        {
+            int dx = 0, dy = 0;
+            switch (quarter_turns_cw)
+            {
+                case 1: dx = src.h - 1 - y; dy = x; break;              // 90 CW
+                case 2: dx = src.w - 1 - x; dy = src.h - 1 - y; break;  // 180
+                case 3: dx = y; dy = src.w - 1 - x; break;              // 270 CW
+            }
+            std::memcpy(&out.data[(size_t(dy) * out.w + dx) * 4], &src.data[(size_t(y) * src.w + x) * 4], 4);
+        }
+    }
+    return out;
+}
+
 #if OSHOT_LINUX
 Result<capture_result_t> capture_full_screen_portal();
 

--- a/src/screen_capture.cpp
+++ b/src/screen_capture.cpp
@@ -110,6 +110,53 @@ SessionType get_session_type()
     return SessionType::Unknown;
 }
 
+Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
+                                         const std::deque<region_t>& monitors,
+                                         const region_t&             target)
+{
+    if (monitors.empty())
+        return Err("No monitor list provided");
+
+    int min_x = monitors[0].x, min_y = monitors[0].y;
+    int max_x = monitors[0].x + monitors[0].width, max_y = monitors[0].y + monitors[0].height;
+    for (const region_t& m : monitors)
+    {
+        min_x = std::min(min_x, m.x);
+        min_y = std::min(min_y, m.y);
+        max_x = std::max(max_x, m.x + m.width);
+        max_y = std::max(max_y, m.y + m.height);
+    }
+    const int layout_w = max_x - min_x;
+    const int layout_h = max_y - min_y;
+    if (layout_w <= 0 || layout_h <= 0)
+        return Err("Degenerate monitor layout");
+
+    const float scale_x = float(full.w) / layout_w;
+    const float scale_y = float(full.h) / layout_h;
+
+    const int crop_x = std::clamp(int(std::lround((target.x - min_x) * scale_x)), 0, full.w);
+    const int crop_y = std::clamp(int(std::lround((target.y - min_y) * scale_y)), 0, full.h);
+    const int crop_w = std::clamp(int(std::lround(target.width * scale_x)), 0, full.w - crop_x);
+    const int crop_h = std::clamp(int(std::lround(target.height * scale_y)), 0, full.h - crop_y);
+
+    if (crop_w <= 0 || crop_h <= 0)
+        return Err("Computed crop rect is empty");
+
+    capture_result_t out;
+    out.w = crop_w;
+    out.h = crop_h;
+    out.data.resize(size_t(crop_w) * crop_h * 4);
+
+    for (int row = 0; row < crop_h; ++row)
+    {
+        const uint8_t* src = full.data.data() + (size_t(crop_y + row) * full.w + crop_x) * 4;
+        uint8_t*       dst = out.data.data() + size_t(row) * crop_w * 4;
+        std::memcpy(dst, src, size_t(crop_w) * 4);
+    }
+
+    return Ok(std::move(out));
+}
+
 #if OSHOT_LINUX
 Result<capture_result_t> capture_full_screen_portal();
 
@@ -292,7 +339,7 @@ Result<capture_result_t> capture_full_screen_spectacle()
     unlink(tmppath);
 
     if (!rgba)
-        return Err("Failed to decode PNG: {}", STBI_ERROR);
+        return Err("Failed to read PNG: {}", STBI_ERROR);
 
     result.w = w;
     result.h = h;
@@ -310,19 +357,22 @@ Result<capture_result_t> capture_full_screen_wayland()
 
     capture_result_t result;
 
+    std::string             err;
     std::vector<uint8_t>    buf;
-    TinyProcessLib::Process proc({ "grim", "-t", "ppm", "-" },
-                                 "",  // cwd
-                                 [&](const char* bytes, size_t n) {
-                                     // stdout (binary)
-                                     const uint8_t* p = reinterpret_cast<const uint8_t*>(bytes);
-                                     buf.insert(buf.end(), p, p + n);
-                                 });
-
-    const int exit_code = proc.get_exit_status();
-
-    if (exit_code != 0)
-        return Err("grim failed with exit code: {}", exit_code);
+    TinyProcessLib::Process proc(
+        { "grim", "-t", "ppm", "-" },
+        "",  // cwd
+        [&](const char* bytes, size_t n) {
+            // stdout (binary)
+            const uint8_t* p = reinterpret_cast<const uint8_t*>(bytes);
+            buf.insert(buf.end(), p, p + n);
+        },
+        [&](const char* p, size_t n) {
+            // stderr
+            err.append(p, n);
+        });
+    if (proc.get_exit_status() != 0)
+        return Err("Capture with grim failed: {}", err);
 
     // stbi_load_from_memory takes an int length
     if (buf.size() > INT_MAX)
@@ -336,7 +386,7 @@ Result<capture_result_t> capture_full_screen_wayland()
 
     result.w = w;
     result.h = h;
-    result.data.assign(rgba, rgba + (size_t(w) * size_t(h) * 4));
+    result.data.assign(rgba, rgba + (size_t(w) * h * 4));
     stbi_image_free(rgba);
 
     return Ok(std::move(result));
@@ -570,7 +620,6 @@ Result<capture_result_t> capture_full_screen_portal()
 
     return Ok(std::move(st.cap));
 }
-
 #else
 Result<capture_result_t> capture_full_screen_x11()
 {

--- a/src/screen_capture.cpp
+++ b/src/screen_capture.cpp
@@ -58,9 +58,6 @@
 #  include <dxgi1_2.h>
 #  include <stdio.h>
 #  include <windows.h>
-
-#  pragma comment(lib, "d3d11")
-#  pragma comment(lib, "dxgi")
 #endif
 
 using namespace spdlog;
@@ -162,15 +159,15 @@ Result<capture_result_t> crop_to_monitor(const capture_result_t&     full,
 // output for outputs with a non-zero wl_output transform (rotated monitors),
 // since the compositor's combined capture buffer doesn't pre-rotate per-output
 // content the way logical geometry implies it should.
-capture_result_t rotate_rgba(const capture_result_t& src, int quarter_turns_cw)
+capture_result_t rotate_rgba(const capture_result_t& src, int turns_cw)
 {
-    quarter_turns_cw = ((quarter_turns_cw % 4) + 4) % 4;
-    if (quarter_turns_cw == 0)
+    turns_cw = ((turns_cw % 4) + 4) % 4;
+    if (turns_cw == 0)
         return src;
 
     capture_result_t out;
-    out.w = (quarter_turns_cw % 2 == 0) ? src.w : src.h;
-    out.h = (quarter_turns_cw % 2 == 0) ? src.h : src.w;
+    out.w = (turns_cw % 2 == 0) ? src.w : src.h;
+    out.h = (turns_cw % 2 == 0) ? src.h : src.w;
     out.data.resize(size_t(out.w) * out.h * 4);
 
     for (int y = 0; y < src.h; ++y)
@@ -178,13 +175,24 @@ capture_result_t rotate_rgba(const capture_result_t& src, int quarter_turns_cw)
         for (int x = 0; x < src.w; ++x)
         {
             int dx = 0, dy = 0;
-            switch (quarter_turns_cw)
+            switch (turns_cw)
             {
-                case 1: dx = src.h - 1 - y; dy = x; break;              // 90 CW
-                case 2: dx = src.w - 1 - x; dy = src.h - 1 - y; break;  // 180
-                case 3: dx = y; dy = src.w - 1 - x; break;              // 270 CW
+                case 1:  // 90 CW
+                    dx = src.h - 1 - y;
+                    dy = x;
+                    break;
+                case 2:  // 180
+                    dx = src.w - 1 - x;
+                    dy = src.h - 1 - y;
+                    break;
+                case 3:  // 270 CW
+                    dx = y;
+                    dy = src.w - 1 - x;
+                    break;
             }
-            std::memcpy(&out.data[(size_t(dy) * out.w + dx) * 4], &src.data[(size_t(y) * src.w + x) * 4], 4);
+            const uint8_t* psrc = src.data.data() + (size_t(y) * src.w + x) * 4;
+            uint8_t*       pdst = out.data.data() + (size_t(dy) * out.w + dx) * 4;
+            std::memcpy(pdst, psrc, 4);
         }
     }
     return out;
@@ -385,7 +393,7 @@ Result<capture_result_t> capture_full_screen_spectacle()
 
 Result<capture_result_t> capture_full_screen_wayland()
 {
-    const Result<capture_result_t> res = capture_full_screen_portal();
+    Result<capture_result_t> res = capture_full_screen_portal();
     if (res.ok())
         return res;
 

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -3623,9 +3623,8 @@ void ScreenshotTool::DrawOutputMenuSelection()
         layout.push_back(m.geo);
 
         ImGui::PushID(int(i));
-        ImGui::RadioButton(fmt::format("{} ({}x{})", m.name[0] ? m.name : "Unknown", m.geo.width, m.geo.height).c_str(),
-                           &output_sel,
-                           int(i));
+        ImGui::RadioButton(
+            fmt::format("{} ({}x{})", m.name[0] ? m.name : "Unknown", m.geo.w, m.geo.h).c_str(), &output_sel, int(i));
         ImGui::PopID();
     }
 
@@ -3729,21 +3728,21 @@ capture_result_t ScreenshotTool::GetFinalImage(bool is_text_tools)
     const region_t& region = GetActiveRegion();
 
     capture_result_t result;
-    result.w = region.width;
-    result.h = region.height;
-    result.data.resize(size_t(region.width) * region.height * 4);
+    result.w = region.w;
+    result.h = region.h;
+    result.data.resize(size_t(region.w) * region.h * 4);
 
     std::span<const uint8_t> src(m_screenshot.view());
     std::span<uint8_t>       dst(result.data);
 
     const int src_width = m_screenshot.w;
-    const int dst_width = region.width;
+    const int dst_width = region.w;
 
     // Calculate bounds
     const int start_y = std::max(0, -region.y);
-    const int end_y   = std::min(region.height, m_screenshot.h - region.y);
+    const int end_y   = std::min(region.h, m_screenshot.h - region.y);
     const int start_x = std::max(0, -region.x);
-    const int end_x   = std::min(region.width, m_screenshot.w - region.x);
+    const int end_x   = std::min(region.w, m_screenshot.w - region.x);
 
     int width = end_x - start_x;
 

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -4122,42 +4122,14 @@ void ScreenshotTool::UpdateWindowBg()
 
 Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const monitor_t& target)
 {
-    // Taken from /usr/include/wayland-client-protocol.h
-    enum wl_output_transform
-    {
-        /**
-         * no transform
-         */
-        WL_OUTPUT_TRANSFORM_NORMAL = 0,
-        /**
-         * 90 degrees counter-clockwise
-         */
-        WL_OUTPUT_TRANSFORM_90 = 1,
-        /**
-         * 180 degrees counter-clockwise
-         */
-        WL_OUTPUT_TRANSFORM_180 = 2,
-        /**
-         * 270 degrees counter-clockwise
-         */
-        WL_OUTPUT_TRANSFORM_270 = 3
-    };
-
     Result<capture_result_t> cropped = crop_to_monitor(m_screenshot, layout, target.geo);
     TRY_MSG(cropped, "Failed to crop capture to focused monitor: {}");
 
     m_screenshot = std::move(cropped.get());
 
-    int quarter_turns = 0;
-    switch (target.transform)
-    {
-        case WL_OUTPUT_TRANSFORM_90:  quarter_turns = 1; break;
-        case WL_OUTPUT_TRANSFORM_180: quarter_turns = 2; break;
-        case WL_OUTPUT_TRANSFORM_270: quarter_turns = 3; break;
-        default:                      break;  // normal, or flipped variants, not handled yet
-    }
-    if (quarter_turns != 0)
-        m_screenshot = rotate_rgba(m_screenshot, quarter_turns);
+    // WL_OUTPUT_TRANSFORM_90/180/270
+    if (target.transform >= 1 && target.transform <= 3)
+        m_screenshot = rotate_rgba(m_screenshot, target.transform);
 
     const Result<ImTextureRef>& r = CreateTexture(reinterpret_cast<void*>(static_cast<size_t>(m_texture_id._TexID)),
                                                   m_screenshot.view(),

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -352,7 +352,7 @@ Result<> ScreenshotTool::Start()
         if (m_session == SessionType::Wayland)
         {
             m_wayland_monitors = wl_get_monitors();
-            if (m_wayland_monitors.size() > 1)
+            if (m_wayland_monitors.size() > 0)
                 m_show_window.Set(SubWindow::OutputMenuSelection);
         }
 #endif
@@ -3607,6 +3607,7 @@ void ScreenshotTool::DrawOutputMenuSelection()
         return;
 
     static int output_sel = 0;
+    static int trans_sel  = 0;
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16, 14));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8, 10));
@@ -3616,6 +3617,8 @@ void ScreenshotTool::DrawOutputMenuSelection()
     ImGui::Begin("Choose an output to capture##select_output_crop",
                  nullptr,
                  ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+
+    ImGui::SeparatorText("Output");
 
     std::deque<region_t> layout;
 
@@ -3630,17 +3633,28 @@ void ScreenshotTool::DrawOutputMenuSelection()
         ImGui::PopID();
     }
 
-    output_sel = layout.empty() ? 0 : std::clamp(output_sel, 0, static_cast<int>(layout.size()) - 1);
+    output_sel              = layout.empty() ? 0 : std::clamp(output_sel, 0, static_cast<int>(layout.size()) - 1);
+    const monitor_t& target = m_wayland_monitors[output_sel];
 
+    ImGui::SeparatorText("Debug");
+    ImGui::TextDisabled("Detected transform: %d", target.transform);
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::Combo("##rotate_combo", &trans_sel, "No Rotation\0Left Rotation\0Down Rotation\0Right Rotation\0\0");
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip(
+            "Overrides the auto-detected output rotation for this crop.\nShould normally stay \"No Rotation\".");
+
+    ImGui::Spacing();
     ImGui::Separator();
+    ImGui::Spacing();
 
     const float button_width = ImGui::GetContentRegionAvail().x;
     ImGui::BeginDisabled(layout.empty());
     if (ImGui::Button("Crop", ImVec2(button_width, 0)))
     {
-        const monitor_t& target = m_wayland_monitors[output_sel];
         m_show_window.Clear(SubWindow::OutputMenuSelection);
-        MUST_OK(g_ss_tool.CropToOutput(layout, target), error("Crop to focused monitor failed: {}", _r.error_v()));
+        MUST_OK(g_ss_tool.CropToOutput(layout, target, trans_sel),
+                error("Crop to focused monitor failed: {}", _r.error_v()));
     }
     ImGui::EndDisabled();
 
@@ -4117,7 +4131,7 @@ void ScreenshotTool::UpdateWindowBg()
     // clang-format on
 }
 
-Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const monitor_t& target)
+Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const monitor_t& target, int transform)
 {
     Result<capture_result_t> cropped = crop_to_monitor(m_screenshot, layout, target.geo);
     TRY_MSG(cropped, "Failed to crop capture to focused monitor: {}");
@@ -4125,9 +4139,8 @@ Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const 
     m_screenshot = std::move(cropped.get());
 
     spdlog::debug("target.transform = {}", target.transform);
-    // WL_OUTPUT_TRANSFORM_90/180/270
-    if (target.transform >= 1 && target.transform <= 3)
-        m_screenshot = rotate_rgba(m_screenshot, 4 - target.transform);  // swap 1 (90) and 3 (270)
+    if (transform >= 1 && transform <= 3)
+        m_screenshot = rotate_rgba(m_screenshot, 4 - transform);  // swap 1 (90) and 3 (270)
 
     const Result<ImTextureRef>& r = CreateTexture(reinterpret_cast<void*>(static_cast<size_t>(m_texture_id._TexID)),
                                                   m_screenshot.view(),

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -52,7 +52,6 @@
 #include "imgui/imgui_impl_opengl3_loader.h"
 #include "imgui/imgui_internal.h"
 #include "imgui/imgui_stdlib.h"
-#include "spdlog/spdlog.h"
 #ifndef DISABLE_PLUGINS
 #  include "plugin.hpp"
 #  include "plugins/oshot_plugin.h"
@@ -67,16 +66,11 @@
 #include "tool_icons.h"
 #include "util.hpp"
 
-#define GL_SILENCE_DEPRECATION
-#include <GLFW/glfw3.h>
-
 #ifndef GL_NO_ERROR
 #  define GL_NO_ERROR 0
 #endif
 
-#if OSHOT_LINUX
 std::deque<monitor_t> wl_get_monitors();
-#endif
 
 using namespace std::chrono_literals;
 

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -3642,7 +3642,7 @@ void ScreenshotTool::DrawOutputMenuSelection()
     ImGui::BeginDisabled(layout.empty());
     if (ImGui::Button("Crop", ImVec2(button_width, 0)))
     {
-        const region_t target = layout[output_sel];
+        const monitor_t& target = m_wayland_monitors[output_sel];
         m_show_window.Clear(SubWindow::OutputMenuSelection);
         MUST_OK(g_ss_tool.CropToOutput(layout, target), error("Crop to focused monitor failed: {}", _r.error_v()));
     }
@@ -4120,12 +4120,44 @@ void ScreenshotTool::UpdateWindowBg()
     // clang-format on
 }
 
-Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const region_t& target)
+Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const monitor_t& target)
 {
-    Result<capture_result_t> cropped = crop_to_monitor(m_screenshot, layout, target);
+    // Taken from /usr/include/wayland-client-protocol.h
+    enum wl_output_transform
+    {
+        /**
+         * no transform
+         */
+        WL_OUTPUT_TRANSFORM_NORMAL = 0,
+        /**
+         * 90 degrees counter-clockwise
+         */
+        WL_OUTPUT_TRANSFORM_90 = 1,
+        /**
+         * 180 degrees counter-clockwise
+         */
+        WL_OUTPUT_TRANSFORM_180 = 2,
+        /**
+         * 270 degrees counter-clockwise
+         */
+        WL_OUTPUT_TRANSFORM_270 = 3
+    };
+
+    Result<capture_result_t> cropped = crop_to_monitor(m_screenshot, layout, target.geo);
     TRY_MSG(cropped, "Failed to crop capture to focused monitor: {}");
 
     m_screenshot = std::move(cropped.get());
+
+    int quarter_turns = 0;
+    switch (target.transform)
+    {
+        case WL_OUTPUT_TRANSFORM_90:  quarter_turns = 1; break;
+        case WL_OUTPUT_TRANSFORM_180: quarter_turns = 2; break;
+        case WL_OUTPUT_TRANSFORM_270: quarter_turns = 3; break;
+        default:                      break;  // normal, or flipped variants, not handled yet
+    }
+    if (quarter_turns != 0)
+        m_screenshot = rotate_rgba(m_screenshot, quarter_turns);
 
     const Result<ImTextureRef>& r = CreateTexture(reinterpret_cast<void*>(static_cast<size_t>(m_texture_id._TexID)),
                                                   m_screenshot.view(),

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -357,6 +357,7 @@ Result<> ScreenshotTool::Start()
     m_tool_thickness.fill(3.0f);
     m_tool_thickness[idx(ToolType::Text)] = 16.0f;
 
+    spdlog::debug("captured screenshots: {}x{}, size: {}", m_screenshot.w, m_screenshot.h, m_screenshot.view().size());
     return Ok();
 }
 
@@ -3597,7 +3598,8 @@ void ScreenshotTool::DrawOutputMenuSelection()
     if (!m_show_window.Has(SubWindow::OutputMenuSelection))
         return;
 
-    static int output_sel = 0;
+    static int  output_sel = 0;
+    static bool do_debug   = true;
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16, 14));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8, 10));
@@ -3622,19 +3624,21 @@ void ScreenshotTool::DrawOutputMenuSelection()
         if (!mode)
             continue;
 
-        const char* mon_orientation = mode->height > mode->width ? "Vertical" : "Horizontal";
-        layout.push_back(region_t{ mx, my, mode->width, mode->height });
+        region_t r{ mx, my, mode->width, mode->height };
+        if (do_debug)
+            spdlog::debug("monitor {}: {}x{}+{}+{}", mon_name, r.width, r.height, r.x, r.y);
+        layout.emplace_back(std::move(r));
 
         const int idx = static_cast<int>(layout.size()) - 1;
         ImGui::PushID(idx);
         ImGui::RadioButton(
-            fmt::format("{} ({}x{}, {})", mon_name ? mon_name : "Unknown", mode->width, mode->height, mon_orientation)
-                .c_str(),
+            fmt::format("{} ({}x{})", mon_name ? mon_name : "Unknown", mode->width, mode->height).c_str(),
             &output_sel,
             idx);
         ImGui::PopID();
     }
 
+    do_debug   = false;
     output_sel = layout.empty() ? 0 : std::clamp(output_sel, 0, static_cast<int>(layout.size()) - 1);
 
     ImGui::Separator();

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -352,7 +352,8 @@ Result<> ScreenshotTool::Start()
         if (m_session == SessionType::Wayland)
         {
             m_wayland_monitors = wl_get_monitors();
-            m_show_window.Set(SubWindow::OutputMenuSelection);
+            if (m_wayland_monitors.size() > 1)
+                m_show_window.Set(SubWindow::OutputMenuSelection);
         }
 #endif
     }
@@ -3601,6 +3602,7 @@ void ScreenshotTool::DrawAnnotations()
 
 void ScreenshotTool::DrawOutputMenuSelection()
 {
+#if OSHOT_LINUX
     if (!m_show_window.Has(SubWindow::OutputMenuSelection))
         return;
 
@@ -3644,6 +3646,7 @@ void ScreenshotTool::DrawOutputMenuSelection()
 
     ImGui::End();
     ImGui::PopStyleVar(2);
+#endif
 }
 
 void ScreenshotTool::Cancel()

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -73,7 +73,10 @@
 #  define GL_NO_ERROR 0
 #endif
 
+#if OSHOT_LINUX
 std::deque<monitor_t> wl_get_monitors();
+#endif
+
 using namespace std::chrono_literals;
 
 constexpr rgba_t::rgba_t(ImVec4 vec)
@@ -350,11 +353,13 @@ Result<> ScreenshotTool::Start()
         }
         TRY_MSG(result, "Failed to capture screenshot: {}");
 
+#if OSHOT_LINUX
         if (m_session == SessionType::Wayland)
         {
             m_wayland_monitors = wl_get_monitors();
             m_show_window.Set(SubWindow::OutputMenuSelection);
         }
+#endif
     }
 
     m_screenshot = std::move(result.get());

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -66,6 +66,9 @@
 #include "tool_icons.h"
 #include "util.hpp"
 
+#define GL_SILENCE_DEPRECATION
+#include <GLFW/glfw3.h>
+
 #ifndef GL_NO_ERROR
 #  define GL_NO_ERROR 0
 #endif
@@ -323,17 +326,19 @@ void apply_imgui_theme()
 Result<> ScreenshotTool::Start()
 {
     Result<capture_result_t> result{ Err() };
+    m_session = get_session_type();
 
     if (!g_config->Runtime.source_file.empty())
     {
         result = load_image_rgba(g_config->Runtime.source_file);
+        TRY_MSG(result, "Failed to load image: {}");
     }
     else
     {
         if (g_config->File.delay > 0)
             std::this_thread::sleep_for(std::chrono::milliseconds(g_config->File.delay));
 
-        switch (get_session_type())
+        switch (m_session)
         {
             case SessionType::X11:     result = capture_full_screen_x11(); break;
             case SessionType::Wayland: result = capture_full_screen_wayland(); break;
@@ -342,13 +347,16 @@ Result<> ScreenshotTool::Start()
             case SessionType::MacOS:   result = capture_full_screen_macos(); break;
             default:                   return Err("Unknown platform");
         }
-    }
+        TRY_MSG(result, "Failed to capture screenshot: {}");
 
-    TRY_MSG(result, "Failed to load image: {}");
+        if (m_session == SessionType::Wayland)
+            m_show_window.Set(SubWindow::OutputMenuSelection);
+    }
 
     m_screenshot = std::move(result.get());
     m_tool_thickness.fill(3.0f);
     m_tool_thickness[idx(ToolType::Text)] = 16.0f;
+
     return Ok();
 }
 
@@ -481,6 +489,15 @@ void ScreenshotTool::RenderOverlay()
 
     if (ImGui::GetPlatformIO().DrawCallback_SetSamplerLinear)
         ImGui::GetBackgroundDrawList()->AddCallback(ImGui::GetPlatformIO().DrawCallback_SetSamplerLinear, nullptr);
+
+    if (m_session == SessionType::Wayland && m_show_window.Has(SubWindow::OutputMenuSelection))
+    {
+        DrawOutputMenuSelection();
+        DrawDarkOverlay();
+        if (ImGui::IsKeyPressed(ImGuiKey_Escape) && !disable_esc)
+            Cancel();
+        return;
+    }
 
     if (m_selection.get_width() == 0 || m_selection.get_height() == 0)
     {
@@ -3575,6 +3592,67 @@ void ScreenshotTool::DrawAnnotations()
         draw_annotation(m_current_annotation);
 }
 
+void ScreenshotTool::DrawOutputMenuSelection()
+{
+    if (!m_show_window.Has(SubWindow::OutputMenuSelection))
+        return;
+
+    static int output_sel = 0;
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16, 14));
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8, 10));
+
+    ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSizeConstraints(ImVec2(320, 0), ImVec2(520, 480));
+    ImGui::Begin("Choose an output to capture##select_output_crop",
+                 nullptr,
+                 ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
+
+    int           monitor_count = 0;
+    GLFWmonitor** monitors      = extern_glfwGetMonitors(&monitor_count);
+
+    std::deque<region_t> layout;
+
+    for (int i = 0; i < monitor_count; ++i)
+    {
+        int mx, my;
+        extern_glfwGetMonitorPos(monitors[i], &mx, &my);
+        const char*        mon_name = extern_glfwGetMonitorName(monitors[i]);
+        const GLFWvidmode* mode     = extern_glfwGetVideoMode(monitors[i]);
+        if (!mode)
+            continue;
+
+        const char* mon_orientation = mode->height > mode->width ? "Vertical" : "Horizontal";
+        layout.push_back(region_t{ mx, my, mode->width, mode->height });
+
+        const int idx = static_cast<int>(layout.size()) - 1;
+        ImGui::PushID(idx);
+        ImGui::RadioButton(
+            fmt::format("{} ({}x{}, {})", mon_name ? mon_name : "Unknown", mode->width, mode->height, mon_orientation)
+                .c_str(),
+            &output_sel,
+            idx);
+        ImGui::PopID();
+    }
+
+    output_sel = layout.empty() ? 0 : std::clamp(output_sel, 0, static_cast<int>(layout.size()) - 1);
+
+    ImGui::Separator();
+
+    const float button_width = ImGui::GetContentRegionAvail().x;
+    ImGui::BeginDisabled(layout.empty());
+    if (ImGui::Button("Crop", ImVec2(button_width, 0)))
+    {
+        const region_t target = layout[output_sel];
+        m_show_window.Clear(SubWindow::OutputMenuSelection);
+        MUST_OK(g_ss_tool.CropToOutput(layout, target), error("Crop to focused monitor failed: {}", _r.error_v()));
+    }
+    ImGui::EndDisabled();
+
+    ImGui::End();
+    ImGui::PopStyleVar(2);
+}
+
 void ScreenshotTool::Cancel()
 {
     m_state = ToolState::Idle;
@@ -4041,6 +4119,25 @@ void ScreenshotTool::UpdateWindowBg()
         m_image_origin.y + image_size.y
     );
     // clang-format on
+}
+
+Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const region_t& target)
+{
+    Result<capture_result_t> cropped = crop_to_monitor(m_screenshot, layout, target);
+    TRY_MSG(cropped, "Failed to crop capture to focused monitor: {}");
+
+    m_screenshot = std::move(cropped.get());
+
+    const Result<ImTextureRef>& r = CreateTexture(reinterpret_cast<void*>(static_cast<size_t>(m_texture_id._TexID)),
+                                                  m_screenshot.view(),
+                                                  m_screenshot.w,
+                                                  m_screenshot.h);
+    TRY_MSG(r, "Failed to recreate texture after crop: {}");
+    m_texture_id = r.get();
+
+    UpdateWindowBg();  // re-center image_origin/image_end for the new, smaller size
+
+    return Ok();
 }
 
 ImFont* ScreenshotTool::CacheAndGetFont(const std::string& font_path, const float font_size)

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -73,6 +73,7 @@
 #  define GL_NO_ERROR 0
 #endif
 
+std::deque<monitor_t> wl_get_monitors();
 using namespace std::chrono_literals;
 
 constexpr rgba_t::rgba_t(ImVec4 vec)
@@ -350,7 +351,10 @@ Result<> ScreenshotTool::Start()
         TRY_MSG(result, "Failed to capture screenshot: {}");
 
         if (m_session == SessionType::Wayland)
+        {
+            m_wayland_monitors = wl_get_monitors();
             m_show_window.Set(SubWindow::OutputMenuSelection);
+        }
     }
 
     m_screenshot = std::move(result.get());
@@ -497,6 +501,8 @@ void ScreenshotTool::RenderOverlay()
         DrawDarkOverlay();
         if (ImGui::IsKeyPressed(ImGuiKey_Escape) && !disable_esc)
             Cancel();
+        ImGui::End();
+        ImGui::PopStyleVar();
         return;
     }
 
@@ -3598,8 +3604,7 @@ void ScreenshotTool::DrawOutputMenuSelection()
     if (!m_show_window.Has(SubWindow::OutputMenuSelection))
         return;
 
-    static int  output_sel = 0;
-    static bool do_debug   = true;
+    static int output_sel = 0;
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16, 14));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8, 10));
@@ -3610,35 +3615,20 @@ void ScreenshotTool::DrawOutputMenuSelection()
                  nullptr,
                  ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
 
-    int           monitor_count = 0;
-    GLFWmonitor** monitors      = extern_glfwGetMonitors(&monitor_count);
-
     std::deque<region_t> layout;
 
-    for (int i = 0; i < monitor_count; ++i)
+    for (size_t i = 0; i < m_wayland_monitors.size(); ++i)
     {
-        int mx, my;
-        extern_glfwGetMonitorPos(monitors[i], &mx, &my);
-        const char*        mon_name = extern_glfwGetMonitorName(monitors[i]);
-        const GLFWvidmode* mode     = extern_glfwGetVideoMode(monitors[i]);
-        if (!mode)
-            continue;
+        const monitor_t& m = m_wayland_monitors[i];
+        layout.push_back(m.geo);
 
-        region_t r{ mx, my, mode->width, mode->height };
-        if (do_debug)
-            spdlog::debug("monitor {}: {}x{}+{}+{}", mon_name, r.width, r.height, r.x, r.y);
-        layout.emplace_back(std::move(r));
-
-        const int idx = static_cast<int>(layout.size()) - 1;
-        ImGui::PushID(idx);
-        ImGui::RadioButton(
-            fmt::format("{} ({}x{})", mon_name ? mon_name : "Unknown", mode->width, mode->height).c_str(),
-            &output_sel,
-            idx);
+        ImGui::PushID(int(i));
+        ImGui::RadioButton(fmt::format("{} ({}x{})", m.name[0] ? m.name : "Unknown", m.geo.width, m.geo.height).c_str(),
+                           &output_sel,
+                           int(i));
         ImGui::PopID();
     }
 
-    do_debug   = false;
     output_sel = layout.empty() ? 0 : std::clamp(output_sel, 0, static_cast<int>(layout.size()) - 1);
 
     ImGui::Separator();

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -3618,8 +3618,6 @@ void ScreenshotTool::DrawOutputMenuSelection()
                  nullptr,
                  ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
 
-    ImGui::SeparatorText("Output");
-
     std::deque<region_t> layout;
 
     for (size_t i = 0; i < m_wayland_monitors.size(); ++i)
@@ -3636,7 +3634,7 @@ void ScreenshotTool::DrawOutputMenuSelection()
     output_sel              = layout.empty() ? 0 : std::clamp(output_sel, 0, static_cast<int>(layout.size()) - 1);
     const monitor_t& target = m_wayland_monitors[output_sel];
 
-    ImGui::SeparatorText("Debug");
+    ImGui::Spacing();
     ImGui::TextDisabled("Detected transform: %d", target.transform);
     ImGui::SetNextItemWidth(-FLT_MIN);
     ImGui::Combo("##rotate_combo", &trans_sel, "No Rotation\0Left Rotation\0Down Rotation\0Right Rotation\0\0");

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -52,6 +52,7 @@
 #include "imgui/imgui_impl_opengl3_loader.h"
 #include "imgui/imgui_internal.h"
 #include "imgui/imgui_stdlib.h"
+#include "spdlog/spdlog.h"
 #ifndef DISABLE_PLUGINS
 #  include "plugin.hpp"
 #  include "plugins/oshot_plugin.h"
@@ -4127,9 +4128,10 @@ Result<> ScreenshotTool::CropToOutput(const std::deque<region_t>& layout, const 
 
     m_screenshot = std::move(cropped.get());
 
+    spdlog::debug("target.transform = {}", target.transform);
     // WL_OUTPUT_TRANSFORM_90/180/270
     if (target.transform >= 1 && target.transform <= 3)
-        m_screenshot = rotate_rgba(m_screenshot, target.transform);
+        m_screenshot = rotate_rgba(m_screenshot, 4 - target.transform);  // swap 1 (90) and 3 (270)
 
     const Result<ImTextureRef>& r = CreateTexture(reinterpret_cast<void*>(static_cast<size_t>(m_texture_id._TexID)),
                                                   m_screenshot.view(),

--- a/src/screenshot_tool.cpp
+++ b/src/screenshot_tool.cpp
@@ -368,6 +368,8 @@ Result<> ScreenshotTool::Start()
 
 Result<> ScreenshotTool::StartWindow()
 {
+    fit_to_screen(m_screenshot);
+
     // Do not load anything about the text tools window,
     // just the screenshot one
     if (g_config->Runtime.instant_copy_save != SavingOp::kNone)
@@ -411,7 +413,6 @@ Result<> ScreenshotTool::StartWindow()
 
     m_show_window.Set(SubWindow::MainTextTools, g_config->File.show_text_tools);
 
-    fit_to_screen(m_screenshot);
     SyncRuntimeFromConfig();
 
 #if OSHOT_MACOS

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -94,10 +94,15 @@ int  g_sock = -1;
 // Defined and registered in src/main_tool_* source files
 namespace main_tool
 {
-void (*minimize_fn)()         = nullptr;
-void (*maximize_fn)()         = nullptr;
-void (*terminate_fn)()        = nullptr;
-void (*swap_interval_fn)(int) = nullptr;
+void (*minimize_fn)()                                                = nullptr;
+void (*maximize_fn)()                                                = nullptr;
+void (*_extern_glfwTerminate)()                                      = nullptr;
+void (*_extern_glfwSwapInterval)(int)                                = nullptr;
+GLFWmonitor** (*_extern_glfwGetMonitors)(int*)                       = nullptr;
+void (*_extern_glfwGetMonitorPos)(GLFWmonitor* mon, int* x, int* y)  = nullptr;
+void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*) = nullptr;
+const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*)         = nullptr;
+const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*)              = nullptr;
 }  // namespace main_tool
 
 static const std::unordered_map<std::string, std::string>& get_xdg_user_dirs()
@@ -718,13 +723,23 @@ fs::path get_home_pictures_dir()
 
 void register_window_callbacks(void (*minimize_fn)(),
                                void (*maximize_fn)(),
-                               void (*terminate_fn)(),
-                               void (*swap_interval_fn)(int))
+                               void (*_extern_glfwTerminate)(),
+                               void (*_extern_glfwSwapInterval)(int),
+                               GLFWmonitor** (*_extern_glfwGetMonitors)(int*),
+                               void (*_extern_glfwGetMonitorPos)(GLFWmonitor*, int*, int*),
+                               void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*),
+                               const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*),
+                               const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*))
 {
-    main_tool::minimize_fn      = minimize_fn;
-    main_tool::maximize_fn      = maximize_fn;
-    main_tool::terminate_fn     = terminate_fn;
-    main_tool::swap_interval_fn = swap_interval_fn;
+    main_tool::minimize_fn                        = minimize_fn;
+    main_tool::maximize_fn                        = maximize_fn;
+    main_tool::_extern_glfwTerminate              = _extern_glfwTerminate;
+    main_tool::_extern_glfwSwapInterval           = _extern_glfwSwapInterval;
+    main_tool::_extern_glfwGetMonitors            = _extern_glfwGetMonitors;
+    main_tool::_extern_glfwGetMonitorPos          = _extern_glfwGetMonitorPos;
+    main_tool::_extern_glfwGetMonitorPhysicalSize = _extern_glfwGetMonitorPhysicalSize;
+    main_tool::_extern_glfwGetVideoMode           = _extern_glfwGetVideoMode;
+    main_tool::_extern_glfwGetMonitorName         = _extern_glfwGetMonitorName;
 }
 
 void minimize_window()
@@ -739,13 +754,41 @@ void maximize_window()
 }
 void extern_glfwTerminate()
 {
-    if (main_tool::terminate_fn)
-        main_tool::terminate_fn();
+    if (main_tool::_extern_glfwTerminate)
+        main_tool::_extern_glfwTerminate();
 }
 void extern_glfwSwapInterval(int v)
 {
-    if (main_tool::swap_interval_fn)
-        main_tool::swap_interval_fn(v);
+    if (main_tool::_extern_glfwSwapInterval)
+        main_tool::_extern_glfwSwapInterval(v);
+}
+GLFWmonitor** extern_glfwGetMonitors(int* count)
+{
+    if (main_tool::_extern_glfwGetMonitors)
+        return main_tool::_extern_glfwGetMonitors(count);
+    return nullptr;
+}
+void extern_glfwGetMonitorPos(GLFWmonitor* mon, int* xpos, int* ypos)
+{
+    if (main_tool::_extern_glfwGetMonitorPos)
+        main_tool::_extern_glfwGetMonitorPos(mon, xpos, ypos);
+}
+void extern_glfwGetMonitorPhysicalSize(GLFWmonitor* mon, int* widthMM, int* heightMM)
+{
+    if (main_tool::_extern_glfwGetMonitorPhysicalSize)
+        main_tool::_extern_glfwGetMonitorPhysicalSize(mon, widthMM, heightMM);
+}
+const GLFWvidmode* extern_glfwGetVideoMode(GLFWmonitor* mon)
+{
+    if (main_tool::_extern_glfwGetVideoMode)
+        return main_tool::_extern_glfwGetVideoMode(mon);
+    return nullptr;
+}
+const char* extern_glfwGetMonitorName(GLFWmonitor* mon)
+{
+    if (main_tool::_extern_glfwGetMonitorName)
+        return main_tool::_extern_glfwGetMonitorName(mon);
+    return nullptr;
 }
 
 std::string expand_var(std::string ret)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -94,15 +94,10 @@ int  g_sock = -1;
 // Defined and registered in src/main_tool_* source files
 namespace main_tool
 {
-void (*minimize_fn)()                                                = nullptr;
-void (*maximize_fn)()                                                = nullptr;
-void (*_extern_glfwTerminate)()                                      = nullptr;
-void (*_extern_glfwSwapInterval)(int)                                = nullptr;
-GLFWmonitor** (*_extern_glfwGetMonitors)(int*)                       = nullptr;
-void (*_extern_glfwGetMonitorPos)(GLFWmonitor* mon, int* x, int* y)  = nullptr;
-void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*) = nullptr;
-const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*)         = nullptr;
-const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*)              = nullptr;
+void (*minimize_fn)()                 = nullptr;
+void (*maximize_fn)()                 = nullptr;
+void (*_extern_glfwTerminate)()       = nullptr;
+void (*_extern_glfwSwapInterval)(int) = nullptr;
 }  // namespace main_tool
 
 static const std::unordered_map<std::string, std::string>& get_xdg_user_dirs()
@@ -724,22 +719,12 @@ fs::path get_home_pictures_dir()
 void register_window_callbacks(void (*minimize_fn)(),
                                void (*maximize_fn)(),
                                void (*_extern_glfwTerminate)(),
-                               void (*_extern_glfwSwapInterval)(int),
-                               GLFWmonitor** (*_extern_glfwGetMonitors)(int*),
-                               void (*_extern_glfwGetMonitorPos)(GLFWmonitor*, int*, int*),
-                               void (*_extern_glfwGetMonitorPhysicalSize)(GLFWmonitor*, int*, int*),
-                               const GLFWvidmode* (*_extern_glfwGetVideoMode)(GLFWmonitor*),
-                               const char* (*_extern_glfwGetMonitorName)(GLFWmonitor*))
+                               void (*_extern_glfwSwapInterval)(int))
 {
-    main_tool::minimize_fn                        = minimize_fn;
-    main_tool::maximize_fn                        = maximize_fn;
-    main_tool::_extern_glfwTerminate              = _extern_glfwTerminate;
-    main_tool::_extern_glfwSwapInterval           = _extern_glfwSwapInterval;
-    main_tool::_extern_glfwGetMonitors            = _extern_glfwGetMonitors;
-    main_tool::_extern_glfwGetMonitorPos          = _extern_glfwGetMonitorPos;
-    main_tool::_extern_glfwGetMonitorPhysicalSize = _extern_glfwGetMonitorPhysicalSize;
-    main_tool::_extern_glfwGetVideoMode           = _extern_glfwGetVideoMode;
-    main_tool::_extern_glfwGetMonitorName         = _extern_glfwGetMonitorName;
+    main_tool::minimize_fn              = minimize_fn;
+    main_tool::maximize_fn              = maximize_fn;
+    main_tool::_extern_glfwTerminate    = _extern_glfwTerminate;
+    main_tool::_extern_glfwSwapInterval = _extern_glfwSwapInterval;
 }
 
 void minimize_window()
@@ -761,34 +746,6 @@ void extern_glfwSwapInterval(int v)
 {
     if (main_tool::_extern_glfwSwapInterval)
         main_tool::_extern_glfwSwapInterval(v);
-}
-GLFWmonitor** extern_glfwGetMonitors(int* count)
-{
-    if (main_tool::_extern_glfwGetMonitors)
-        return main_tool::_extern_glfwGetMonitors(count);
-    return nullptr;
-}
-void extern_glfwGetMonitorPos(GLFWmonitor* mon, int* xpos, int* ypos)
-{
-    if (main_tool::_extern_glfwGetMonitorPos)
-        main_tool::_extern_glfwGetMonitorPos(mon, xpos, ypos);
-}
-void extern_glfwGetMonitorPhysicalSize(GLFWmonitor* mon, int* widthMM, int* heightMM)
-{
-    if (main_tool::_extern_glfwGetMonitorPhysicalSize)
-        main_tool::_extern_glfwGetMonitorPhysicalSize(mon, widthMM, heightMM);
-}
-const GLFWvidmode* extern_glfwGetVideoMode(GLFWmonitor* mon)
-{
-    if (main_tool::_extern_glfwGetVideoMode)
-        return main_tool::_extern_glfwGetVideoMode(mon);
-    return nullptr;
-}
-const char* extern_glfwGetMonitorName(GLFWmonitor* mon)
-{
-    if (main_tool::_extern_glfwGetMonitorName)
-        return main_tool::_extern_glfwGetMonitorName(mon);
-    return nullptr;
 }
 
 std::string expand_var(std::string ret)

--- a/src/wl_get_monitors.cpp
+++ b/src/wl_get_monitors.cpp
@@ -44,28 +44,28 @@ static const zxdg_output_v1_listener xdg_output_listener = { xdg_output_logical_
                                                              xdg_output_name,
                                                              xdg_output_description };
 
-static void output_geometry(void*             data,
-                            struct wl_output* wl_output,
-                            int32_t           x,
-                            int32_t           y,
-                            int32_t           pw,
-                            int32_t           ph,
-                            int32_t           subpixel,
-                            const char*       make,
-                            const char*       model,
-                            int32_t           transform)
+static void output_geometry(void*       data,
+                            wl_output*  wl_output,
+                            int32_t     x,
+                            int32_t     y,
+                            int32_t     pw,
+                            int32_t     ph,
+                            int32_t     subpixel,
+                            const char* make,
+                            const char* model,
+                            int32_t     transform)
 {
     monitor_t* m = reinterpret_cast<monitor_t*>(data);
     m->geo.x     = x;
     m->geo.y     = y;
 }
 
-static void output_mode(void*             data,
-                        struct wl_output* wl_output,
-                        uint32_t          flags,
-                        int32_t           width,
-                        int32_t           height,
-                        int32_t           refresh)
+static void output_mode(void*      data,
+                        wl_output* wl_output,
+                        uint32_t   flags,
+                        int32_t    width,
+                        int32_t    height,
+                        int32_t    refresh)
 {
     if (flags & WL_OUTPUT_MODE_CURRENT)
     {
@@ -75,25 +75,25 @@ static void output_mode(void*             data,
     }
 }
 
-static void output_done(void* data, struct wl_output* wl_output)
+static void output_done(void* data, wl_output* wl_output)
 {
     reinterpret_cast<monitor_t*>(data)->done = true;
 }
 
-static void output_scale(void* data, struct wl_output* wl_output, int32_t factor)
+static void output_scale(void* data, wl_output* wl_output, int32_t factor)
 {}
 
-static void output_name(void* data, struct wl_output* wl_output, const char* name)
+static void output_name(void* data, wl_output* wl_output, const char* name)
 {
     char* monitor_name = reinterpret_cast<monitor_t*>(data)->name;
     strncpy(monitor_name, name, 63);
 }
 
-static void output_description(void* data, struct wl_output* wl_output, const char* d)
+static void output_description(void* data, wl_output* wl_output, const char* d)
 {}
 
-static const struct wl_output_listener output_listener = { output_geometry, output_mode, output_done,
-                                                           output_scale,    output_name, output_description };
+static const wl_output_listener output_listener = { output_geometry, output_mode, output_done,
+                                                    output_scale,    output_name, output_description };
 
 static void registry_global(void*, wl_registry* registry, uint32_t name, const char* interface, uint32_t version)
 {
@@ -113,10 +113,10 @@ static void registry_global(void*, wl_registry* registry, uint32_t name, const c
     }
 }
 
-static void registry_global_remove(void* data, struct wl_registry* registry, uint32_t name)
+static void registry_global_remove(void* data, wl_registry* registry, uint32_t name)
 {}
 
-static const struct wl_registry_listener registry_listener = { registry_global, registry_global_remove };
+static const wl_registry_listener registry_listener = { registry_global, registry_global_remove };
 
 std::deque<monitor_t> wl_get_monitors()
 {

--- a/src/wl_get_monitors.cpp
+++ b/src/wl_get_monitors.cpp
@@ -24,11 +24,11 @@ static void xdg_output_logical_position(void* data, zxdg_output_v1*, int32_t x, 
     m->geo.y     = y;
 }
 
-static void xdg_output_logical_size(void* data, zxdg_output_v1*, int32_t width, int32_t height)
+static void xdg_output_logical_size(void* data, zxdg_output_v1*, int32_t w, int32_t h)
 {
-    monitor_t* m  = reinterpret_cast<monitor_t*>(data);
-    m->geo.width  = width;
-    m->geo.height = height;
+    monitor_t* m = reinterpret_cast<monitor_t*>(data);
+    m->geo.w     = w;
+    m->geo.h     = h;
 }
 
 static void xdg_output_done(void*, zxdg_output_v1*)
@@ -61,18 +61,13 @@ static void output_geometry(void*       data,
     m->transform = transform;
 }
 
-static void output_mode(void*      data,
-                        wl_output* wl_output,
-                        uint32_t   flags,
-                        int32_t    width,
-                        int32_t    height,
-                        int32_t    refresh)
+static void output_mode(void* data, wl_output* wl_output, uint32_t flags, int32_t w, int32_t h, int32_t refresh)
 {
     if (flags & WL_OUTPUT_MODE_CURRENT)
     {
-        monitor_t* m  = reinterpret_cast<monitor_t*>(data);
-        m->geo.width  = width;
-        m->geo.height = height;
+        monitor_t* m = reinterpret_cast<monitor_t*>(data);
+        m->geo.w     = w;
+        m->geo.h     = h;
     }
 }
 

--- a/src/wl_get_monitors.cpp
+++ b/src/wl_get_monitors.cpp
@@ -135,7 +135,8 @@ std::deque<monitor_t> wl_get_monitors()
     {
         for (monitor_t& m : monitors)
         {
-            zxdg_output_v1* xdg_output = zxdg_output_manager_v1_get_xdg_output(s_xdg_output_manager, m.handle);
+            zxdg_output_v1* xdg_output =
+                zxdg_output_manager_v1_get_xdg_output(s_xdg_output_manager, reinterpret_cast<wl_output*>(m.handle));
             zxdg_output_v1_add_listener(xdg_output, &xdg_output_listener, &m);
         }
     }

--- a/src/wl_get_monitors.cpp
+++ b/src/wl_get_monitors.cpp
@@ -58,6 +58,7 @@ static void output_geometry(void*       data,
     monitor_t* m = reinterpret_cast<monitor_t*>(data);
     m->geo.x     = x;
     m->geo.y     = y;
+    m->transform = transform;
 }
 
 static void output_mode(void*      data,

--- a/src/wl_get_monitors.cpp
+++ b/src/wl_get_monitors.cpp
@@ -1,0 +1,153 @@
+#include <stdlib.h>
+#include <string.h>
+#include <wayland-client.h>
+
+#include <deque>
+
+#include "screen_capture.hpp"
+#include "spdlog/spdlog.h"
+#include "xdg-output-unstable-v1-client-protocol.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+using namespace std::chrono_literals;
+
+static std::deque<monitor_t> monitors;
+
+static zxdg_output_manager_v1* s_xdg_output_manager = nullptr;
+
+static void xdg_output_logical_position(void* data, zxdg_output_v1*, int32_t x, int32_t y)
+{
+    monitor_t* m = reinterpret_cast<monitor_t*>(data);
+    m->geo.x     = x;
+    m->geo.y     = y;
+}
+
+static void xdg_output_logical_size(void* data, zxdg_output_v1*, int32_t width, int32_t height)
+{
+    monitor_t* m  = reinterpret_cast<monitor_t*>(data);
+    m->geo.width  = width;
+    m->geo.height = height;
+}
+
+static void xdg_output_done(void*, zxdg_output_v1*)
+{}
+static void xdg_output_name(void*, zxdg_output_v1*, const char*)
+{}
+static void xdg_output_description(void*, zxdg_output_v1*, const char*)
+{}
+
+static const zxdg_output_v1_listener xdg_output_listener = { xdg_output_logical_position,
+                                                             xdg_output_logical_size,
+                                                             xdg_output_done,
+                                                             xdg_output_name,
+                                                             xdg_output_description };
+
+static void output_geometry(void*             data,
+                            struct wl_output* wl_output,
+                            int32_t           x,
+                            int32_t           y,
+                            int32_t           pw,
+                            int32_t           ph,
+                            int32_t           subpixel,
+                            const char*       make,
+                            const char*       model,
+                            int32_t           transform)
+{
+    monitor_t* m = reinterpret_cast<monitor_t*>(data);
+    m->geo.x     = x;
+    m->geo.y     = y;
+}
+
+static void output_mode(void*             data,
+                        struct wl_output* wl_output,
+                        uint32_t          flags,
+                        int32_t           width,
+                        int32_t           height,
+                        int32_t           refresh)
+{
+    if (flags & WL_OUTPUT_MODE_CURRENT)
+    {
+        monitor_t* m  = reinterpret_cast<monitor_t*>(data);
+        m->geo.width  = width;
+        m->geo.height = height;
+    }
+}
+
+static void output_done(void* data, struct wl_output* wl_output)
+{
+    reinterpret_cast<monitor_t*>(data)->done = true;
+}
+
+static void output_scale(void* data, struct wl_output* wl_output, int32_t factor)
+{}
+
+static void output_name(void* data, struct wl_output* wl_output, const char* name)
+{
+    char* monitor_name = reinterpret_cast<monitor_t*>(data)->name;
+    strncpy(monitor_name, name, 63);
+}
+
+static void output_description(void* data, struct wl_output* wl_output, const char* d)
+{}
+
+static const struct wl_output_listener output_listener = { output_geometry, output_mode, output_done,
+                                                           output_scale,    output_name, output_description };
+
+static void registry_global(void*, wl_registry* registry, uint32_t name, const char* interface, uint32_t version)
+{
+    if (strcmp(interface, wl_output_interface.name) == 0)
+    {
+        wl_output* output = reinterpret_cast<wl_output*>(
+            wl_registry_bind(registry, name, &wl_output_interface, version < 4 ? version : 4));
+
+        monitor_t& m = monitors.emplace_back();
+        m.handle     = output;
+        wl_output_add_listener(output, &output_listener, &m);
+    }
+    else if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0)
+    {
+        s_xdg_output_manager = reinterpret_cast<zxdg_output_manager_v1*>(
+            wl_registry_bind(registry, name, &zxdg_output_manager_v1_interface, 3));
+    }
+}
+
+static void registry_global_remove(void* data, struct wl_registry* registry, uint32_t name)
+{}
+
+static const struct wl_registry_listener registry_listener = { registry_global, registry_global_remove };
+
+std::deque<monitor_t> wl_get_monitors()
+{
+    wl_display* display = wl_display_connect(nullptr);
+    if (!display)
+    {
+        spdlog::error("No wayland display");
+        return {};
+    }
+
+    wl_registry* registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &registry_listener, nullptr);
+    wl_display_roundtrip(display);  // discover wl_outputs + zxdg_output_manager_v1, flush base geometry/mode
+
+    if (s_xdg_output_manager)
+    {
+        for (monitor_t& m : monitors)
+        {
+            zxdg_output_v1* xdg_output = zxdg_output_manager_v1_get_xdg_output(s_xdg_output_manager, m.handle);
+            zxdg_output_v1_add_listener(xdg_output, &xdg_output_listener, &m);
+        }
+    }
+    else
+    {
+        spdlog::warn("Compositor lacks xdg-output; rotated/scaled monitor geometry may be wrong");
+    }
+
+    wl_display_roundtrip(display);  // flush logical_position/logical_size, overwrites raw mode values
+
+    wl_display_disconnect(display);
+    return monitors;
+}
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Fixed `flake.nix` and `flake.lock` so that they can be utilized with different branches as well as updated them to latest version so they can actually be used. The `flake.nix` file needs to be added to all branches initially so that they can actually be built, but then it will work fine, only needing updates when new version comes out that has new dependencies involved.